### PR TITLE
fix(architecture): Исправление транзакционных багов, внедрение TransactionTemplate

### DIFF
--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/ClassStudentService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/ClassStudentService.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 import java.util.Set;
@@ -25,6 +26,7 @@ public class ClassStudentService {
     private final SchoolClassRepository schoolClassRepository;
     private final ClassStudentRepository classStudentRepository;
     private final UserClient userClient;
+    private final TransactionTemplate writeTransactionTemplate;
 
     @Lazy
     @Autowired
@@ -37,24 +39,22 @@ public class ClassStudentService {
 
     public void addStudent(Long classId, Long studentId) {
         userClient.existStudentById(studentId);
-        self.addStudentTransactional(classId, studentId);
-    }
+        writeTransactionTemplate.execute(status -> {
+            if (!schoolClassRepository.existsById(classId)) {
+                throw new NotFoundException("SchoolClass with id " + classId + " not found", ExceptionCode.SCHOOL_CLASS_NOT_FOUND);
+            }
+            if (classStudentRepository.existsByStudentId(studentId)) {
+                throw new ConflictException("Student already exists in class", ExceptionCode.SCHOOL_CLASS_STUDENT_ALREADY_PRESENT);
+            }
 
-    @Transactional
-    public void addStudentTransactional(Long classId, Long studentId) {
-        if (!schoolClassRepository.existsById(classId)) {
-            throw new NotFoundException("SchoolClass with id " + classId + " not found", ExceptionCode.SCHOOL_CLASS_NOT_FOUND);
-        }
-        if (classStudentRepository.existsByStudentId(studentId)) {
-            throw new ConflictException("Student already exists in class", ExceptionCode.SCHOOL_CLASS_STUDENT_ALREADY_PRESENT);
-        }
+            SchoolClass schoolClass = schoolClassRepository.getReferenceById(classId);
 
-        SchoolClass schoolClass = schoolClassRepository.getReferenceById(classId);
-
-        classStudentRepository.save(ClassStudent.builder()
-                .schoolClass(schoolClass)
-                .studentId(studentId)
-                .build());
+            classStudentRepository.save(ClassStudent.builder()
+                    .schoolClass(schoolClass)
+                    .studentId(studentId)
+                    .build());
+            return null;
+        });
     }
 
     @Transactional

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/FinalGradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/FinalGradeService.java
@@ -19,6 +19,8 @@ import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeRequest;
 import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeResponse;
 import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeTeacherResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +41,13 @@ public class FinalGradeService {
     private final UserClient userClient;
     private final AcademicYearRepository academicYearRepository;
 
+    record DbData(List<FinalGrade> finalGrades, List<Long> studentIds) {}
+
+    @Lazy
+    @Autowired
+    private FinalGradeService self;
+
+
     @Transactional(readOnly = true)
     public Map<String, FinalGradeResponse> getByStudentId(Long studentId, Long academicYearId) {
         List<FinalGrade> finalGrades = finalGradeRepository.findFinalGradesByStudentId(studentId, academicYearId);
@@ -50,21 +59,26 @@ public class FinalGradeService {
                 ));
     }
 
-    @Transactional(readOnly = true)
     public List<FinalGradeTeacherResponse> getByAssignmentId(Long teachingAssignmentId, Long academicYearId) {
-        List<FinalGrade> finalGrades = finalGradeRepository.findFinalGradesByTeachingAssignmentId(teachingAssignmentId, academicYearId);
-        List<FinalGradeResponse> mappedFinalGrades = finalGrades.stream().map(finalGradeMapper::toFinalGradeResponse).toList();
+        DbData data = self.getByAssignmentTransactional(teachingAssignmentId, academicYearId);
+        List<FinalGradeResponse> mappedFinalGrades = data.finalGrades().stream().map(finalGradeMapper::toFinalGradeResponse).toList();
         Map<Long, List<FinalGradeResponse>> finalGradesMap = mappedFinalGrades.stream().collect(Collectors.groupingBy(
                 FinalGradeResponse::studentId,
                 HashMap::new,
                 Collectors.toList()
         ));
 
-        List<Long> studentIds = teachingAssignmentService.getStudentIdsByTeachingAssignmentId(teachingAssignmentId);
-        List<UserFeignResponse> students = userClient.getBatchUsers(studentIds).found();
+        List<UserFeignResponse> students = userClient.getBatchUsers(data.studentIds()).found();
 
         return students.stream().map(user ->
                 new FinalGradeTeacherResponse(user, finalGradesMap.get(user.id()))).toList();
+    }
+
+    @Transactional
+    DbData getByAssignmentTransactional(Long teachingAssignmentId, Long academicYearId) {
+        List<FinalGrade> finalGrades = finalGradeRepository.findFinalGradesByTeachingAssignmentId(teachingAssignmentId, academicYearId);
+        List<Long> studentIds = teachingAssignmentService.getStudentIdsByTeachingAssignmentId(teachingAssignmentId);
+        return new DbData(finalGrades, studentIds);
     }
 
     @Transactional

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/GradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/GradeService.java
@@ -22,11 +22,13 @@ import com.rusobr.academic.web.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +41,7 @@ public class GradeService {
     private final AcademicPeriodService academicPeriodService;
     private final AcademicPeriodRepository academicPeriodRepository;
     private final UserClient userClient;
+    private final TransactionTemplate readOnlyTransactionTemplate;
 
     @Transactional(readOnly = true)
     public GradeResponse getById(Long id) {
@@ -66,8 +69,10 @@ public class GradeService {
     }
 
     public GradeDetailResponse getDetail(Long id) {
-        GradeDetailProjection gradeProjection = gradeRepository.findDetailById(id)
-                .orElseThrow(() -> new NotFoundException("Grade with id: %d not found".formatted(id), ExceptionCode.GRADE_NOT_FOUND));
+        GradeDetailProjection gradeProjection = Objects.requireNonNull(readOnlyTransactionTemplate.execute(status ->
+             gradeRepository.findDetailById(id)
+                    .orElseThrow(() -> new NotFoundException("Grade with id: %d not found".formatted(id), ExceptionCode.GRADE_NOT_FOUND))
+        ));
         UserFeignResponse teacher = userClient.getTeacherSimpleById(gradeProjection.getTeacherId());
         return gradeMapper.toGradeDetailResponse(gradeProjection, teacher);
     }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/JournalService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/JournalService.java
@@ -17,6 +17,7 @@ import com.rusobr.academic.web.dto.lessonInstance.teacher.TeacherJournalResponse
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -36,6 +37,15 @@ public class JournalService {
     private final UserClient userClient;
     private final LessonInstanceMapper lessonInstanceMapper;
     private final AcademicPeriodService academicPeriodService;
+    private final TransactionTemplate readOnlyTransactionTemplate;
+
+    private record JournalDbData(
+            AcademicPeriod academicPeriod,
+            List<LessonInstanceDto> lessonInstances,
+            List<Long> studentsIds,
+            List<GradeStudentDto> grades,
+            List<AttendanceStudentDto> attendances
+    ) {}
 
     @Transactional(readOnly = true)
     public GradesLessonsResponse getGradesLessonsByStudentId(Long studentId, Long academicPeriodId) {
@@ -75,69 +85,75 @@ public class JournalService {
         return new GradesLessonsResponse(academicPeriodMapper.toResponse(academicPeriod), dates, subjects);
     }
 
-    public TeacherJournalResponse getJournalByAssignment(Long teachingAssignmentId,
-                                                         Long academicPeriodId) {
-        //Получаем Academic period
+    public TeacherJournalResponse getJournalByAssignment(Long teachingAssignmentId, Long academicPeriodId) {
+        JournalDbData data = Objects.requireNonNull(readOnlyTransactionTemplate.execute(status ->
+                fetchJournalData(teachingAssignmentId, academicPeriodId)));
+
+        BatchUserResponse students = userClient.getBatchUsers(data.studentsIds());
+
+        List<StudentJournalDto> studentJournal = buildStudentJournal(data.grades(), data.attendances());
+
+        return new TeacherJournalResponse(
+                academicPeriodMapper.toResponse(data.academicPeriod()),
+                students,
+                data.lessonInstances(),
+                studentJournal
+        );
+    }
+
+    private JournalDbData fetchJournalData(Long teachingAssignmentId, Long academicPeriodId) {
         AcademicPeriod academicPeriod = academicPeriodService.getById(academicPeriodId);
 
-        //Получаем экземпляры lessonInstance для верхней строки таблицы
-        List<LessonInstanceDto> lessonInstances = lessonInstanceRepository.findLessonInstanceByTeachingAssignmentId(teachingAssignmentId,
-                academicPeriod.getStartDate(), academicPeriod.getEndDate())
+        List<LessonInstanceDto> lessonInstances = lessonInstanceRepository
+                .findLessonInstanceByTeachingAssignmentId(teachingAssignmentId, academicPeriod.getStartDate(), academicPeriod.getEndDate())
                 .stream().map(lessonInstanceMapper::toLessonInstanceDto).toList();
 
-        //Получаем список учеников с именами
         List<Long> studentsIds = schoolClassRepository.findStudentsIdsByTeachingAssignment(teachingAssignmentId);
-        BatchUserResponse students = userClient.getBatchUsers(studentsIds);
 
-        //Получаем оценки и посещаемость из базы данных
-        List<GradeStudentDto> grades = lessonInstanceRepository.findGradesByTeachingAssignment(teachingAssignmentId,
-                academicPeriod.getStartDate(), academicPeriod.getEndDate())
+        List<GradeStudentDto> grades = lessonInstanceRepository
+                .findGradesByTeachingAssignment(teachingAssignmentId, academicPeriod.getStartDate(), academicPeriod.getEndDate())
                 .stream().map(lessonInstanceMapper::toGradeStudentDto).toList();
 
-        List<AttendanceStudentDto> attendances = lessonInstanceRepository.findAttendancesByTeachingAssignment(
-                teachingAssignmentId,
-                academicPeriod.getStartDate(), academicPeriod.getEndDate())
+        List<AttendanceStudentDto> attendances = lessonInstanceRepository
+                .findAttendancesByTeachingAssignment(teachingAssignmentId, academicPeriod.getStartDate(), academicPeriod.getEndDate())
                 .stream().map(lessonInstanceMapper::toAttendanceStudentDto).toList();
 
-        //Группируем оценки и посещаемость по id ученика
+        return new JournalDbData(academicPeriod, lessonInstances, studentsIds, grades, attendances);
+    }
+
+    private List<StudentJournalDto> buildStudentJournal(List<GradeStudentDto> grades, List<AttendanceStudentDto> attendances) {
         var gradeJournal = grades.stream()
                 .collect(Collectors.groupingBy(GradeStudentDto::studentId, LinkedHashMap::new, Collectors.mapping(
-                        p -> new StudentJournalDto.GradeLessonTeacherDto(
-                                p.gradeId(), p.value(), p.weight(), p.gradeType(), p.lessonInstanceId()
-                        ),
-                Collectors.toList())));
+                        p -> new StudentJournalDto.GradeLessonTeacherDto(p.gradeId(), p.value(), p.weight(), p.gradeType(), p.lessonInstanceId()),
+                        Collectors.toList())));
 
         var attendanceJournal = attendances.stream()
                 .collect(Collectors.groupingBy(AttendanceStudentDto::studentId, LinkedHashMap::new, Collectors.mapping(
-                        p -> new StudentJournalDto.AttendanceLessonTeacherDto(
-                                p.attendanceId(), p.status(), p.lessonInstanceId()
-                        ),
-                Collectors.toList())));
+                        p -> new StudentJournalDto.AttendanceLessonTeacherDto(p.attendanceId(), p.status(), p.lessonInstanceId()),
+                        Collectors.toList())));
 
-        //Собираем все в один список
         Set<Long> allStudentIds = new LinkedHashSet<>();
         allStudentIds.addAll(gradeJournal.keySet());
         allStudentIds.addAll(attendanceJournal.keySet());
 
-        //Преобразуем в dto с studentId и списком оценок и посещаемости
-        List <StudentJournalDto > studentJournal = allStudentIds.stream().map(studentId -> {
+        return allStudentIds.stream()
+                .map(studentId -> {
                     var studentGrades = gradeJournal.getOrDefault(studentId, List.of());
-                    //считаем среднее взвешенное и округляем до 2-х знаков
-                    double gradeTop = studentGrades.stream().mapToDouble(g -> g.value() * g.weight()).sum();
-                    double gradeBottom = studentGrades.stream().mapToDouble(StudentJournalDto.GradeLessonTeacherDto::weight).sum();
-                    double average = (gradeBottom > 0)
-                            ? BigDecimal.valueOf(gradeTop / gradeBottom)
-                              .setScale(2, RoundingMode.HALF_UP)
-                              .doubleValue()
-                            : 0.0;
-
                     return new StudentJournalDto(
-                            studentId, gradeJournal.getOrDefault(studentId, List.of()),
-                            average, attendanceJournal.getOrDefault(studentId, List.of())
+                            studentId,
+                            studentGrades,
+                            calculateWeightedAverage(studentGrades),
+                            attendanceJournal.getOrDefault(studentId, List.of())
                     );
-        }).toList();
+                }).toList();
+    }
 
-        return new TeacherJournalResponse(academicPeriodMapper.toResponse(academicPeriod), students, lessonInstances, studentJournal);
+    private double calculateWeightedAverage(List<StudentJournalDto.GradeLessonTeacherDto> grades) {
+        double top = grades.stream().mapToDouble(g -> g.value() * g.weight()).sum();
+        double bottom = grades.stream().mapToDouble(StudentJournalDto.GradeLessonTeacherDto::weight).sum();
+        return bottom > 0
+                ? BigDecimal.valueOf(top / bottom).setScale(2, RoundingMode.HALF_UP).doubleValue()
+                : 0.0;
     }
 
     public List<LessonInstanceDto> getInstancesByAssignment(Long teachingAssignmentId, Long academicPeriodId) {

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/PeriodGradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/PeriodGradeService.java
@@ -20,6 +20,8 @@ import com.rusobr.academic.web.exception.ConflictException;
 import com.rusobr.academic.web.exception.ExceptionCode;
 import com.rusobr.academic.web.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,7 +36,6 @@ import java.util.stream.Collectors;
 public class PeriodGradeService {
 
     private final PeriodGradeRepository periodGradeRepository;
-    private final AcademicPeriodRepository academicPeriodRepository;
     private final TeachingAssignmentRepository teachingAssignmentRepository;
     private final PeriodGradeMapper periodGradeMapper;
     private final UserClient userClient;
@@ -42,6 +43,16 @@ public class PeriodGradeService {
     private final GradeRepository gradeRepository;
     private final GradeMapper gradeMapper;
     private final AcademicPeriodService academicPeriodService;
+
+    private record PeriodGradeDbData(
+            List<Long> studentIds,
+            Map<Long, List<PeriodGradeResponse>> periodGradesMap,
+            Map<Long, Double> averageGradesMap
+    ) {}
+
+    @Lazy
+    @Autowired
+    private PeriodGradeService self;
 
     @Transactional(readOnly = true)
     public Map<String, List<PeriodGradeStudentResponse>> getByStudentId(Long studentId, Long academicYearId) {
@@ -59,34 +70,37 @@ public class PeriodGradeService {
         );
     }
 
-    @Transactional(readOnly = true)
     public List<PeriodGradeTeacherResponse> getByAssignmentWithAverage(Long teachingAssignmentId, Long currentAcademicPeriodId, Long academicYearId) {
+        PeriodGradeDbData data = self.getByAssignmentWithAverageTransactional(teachingAssignmentId, currentAcademicPeriodId, academicYearId);
+
+        List<UserFeignResponse> students = userClient.getBatchUsers(data.studentIds()).found();
+
+        return students.stream()
+                .map(user -> new PeriodGradeTeacherResponse(
+                        user,
+                        data.periodGradesMap().get(user.id()),
+                        data.averageGradesMap().get(user.id())
+                )).toList();
+    }
+
+    @Transactional(readOnly = true)
+    PeriodGradeDbData getByAssignmentWithAverageTransactional(Long teachingAssignmentId, Long currentAcademicPeriodId, Long academicYearId) {
         AcademicPeriod academicPeriod = academicPeriodService.getById(currentAcademicPeriodId);
         List<Long> studentIds = teachingAssignmentService.getStudentIdsByTeachingAssignmentId(teachingAssignmentId);
-        List<UserFeignResponse> students = userClient.getBatchUsers(studentIds).found();
 
         List<PeriodGradeResponse> periodGrades = periodGradeRepository
                 .findPeriodGradesByTeachingAssignmentId(teachingAssignmentId, academicYearId)
                 .stream().map(periodGradeMapper::toPeriodGradeResponse).toList();
         Map<Long, List<PeriodGradeResponse>> periodGradesMap = periodGrades.stream().collect(Collectors.groupingBy(
-                PeriodGradeResponse::studentId,
-                HashMap::new,
-                Collectors.toList()
-        ));
+                PeriodGradeResponse::studentId, HashMap::new, Collectors.toList()));
 
         List<StudentAverageDto> averageGrades = gradeRepository.findAverageStudentsByTeachingAssignment(
-                teachingAssignmentId,
-                academicPeriod.getStartDate(),
-                academicPeriod.getEndDate())
+                        teachingAssignmentId, academicPeriod.getStartDate(), academicPeriod.getEndDate())
                 .stream().map(gradeMapper::toStudentAverageDto).toList();
         Map<Long, Double> averageGradesMap = averageGrades.stream().collect(Collectors.toMap(
-                        StudentAverageDto::studentId,
-                        StudentAverageDto::average
-        ));
+                StudentAverageDto::studentId, StudentAverageDto::average));
 
-        return students.stream().map(user ->
-                new PeriodGradeTeacherResponse(user, periodGradesMap.get(user.id()), averageGradesMap.get(user.id()))
-        ).toList();
+        return new PeriodGradeDbData(studentIds, periodGradesMap, averageGradesMap);
     }
 
     @Transactional

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/SchoolClassService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/SchoolClassService.java
@@ -46,16 +46,8 @@ public class SchoolClassService {
         return schoolClassMapper.toSchoolClassResponse(schoolClass);
     }
 
-    @Transactional(readOnly = true)
     public SchoolClassFullResponse findWithStudentsById(Long id) {
-        SchoolClass schoolClass = schoolClassRepository.findWithClassStudentById(id)
-                .orElseThrow(() -> new NotFoundException("School class with id " + id + " not found",
-                        ExceptionCode.SCHOOL_CLASS_NOT_FOUND));
-
-        return self.findWithStudentsByIdFeign(schoolClass);
-    }
-
-    public SchoolClassFullResponse findWithStudentsByIdFeign(SchoolClass schoolClass) {
+        SchoolClass schoolClass = self.findWithClassStudentByIdTransactional(id);
         BatchUserResponse users = new BatchUserResponse(List.of(), List.of());
         if (!schoolClass.getStudents().isEmpty()) {
             users = userClient.getBatchUsers(
@@ -74,6 +66,13 @@ public class SchoolClassService {
         }
 
         return schoolClassMapper.toSchoolClassFullResponse(schoolClass, users, teacher, schoolClass.getClassTeacherId());
+    }
+
+    @Transactional(readOnly = true)
+    SchoolClass findWithClassStudentByIdTransactional(Long id) {
+        return schoolClassRepository.findWithClassStudentById(id)
+                .orElseThrow(() -> new NotFoundException("School class with id " + id + " not found",
+                        ExceptionCode.SCHOOL_CLASS_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/TeacherSubjectService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/TeacherSubjectService.java
@@ -14,6 +14,8 @@ import com.rusobr.academic.web.exception.ConflictException;
 import com.rusobr.academic.web.exception.ExceptionCode;
 import com.rusobr.academic.web.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +32,10 @@ public class TeacherSubjectService {
     private final TeacherSubjectMapper teacherSubjectMapper;
     private final UserClient userClient;
     private final SubjectRepository subjectRepository;
+
+    @Lazy
+    @Autowired
+    private TeacherSubjectService self;
 
     public List<TeacherSubjectResponse> findAll() {
         //Получаем учителей из базы academic потом идем в user-service и упаковываем в map, где ключ это id пользователя
@@ -56,6 +62,11 @@ public class TeacherSubjectService {
 
         UserFeignResponse teacher = userClient.getTeacherSimpleById(request.teacherId());
 
+        return self.createTransactional(request, id, teacher);
+    }
+
+    @Transactional
+    TeacherSubjectResponse createTransactional(TeacherSubjectRequest request, TeacherSubjectId id, UserFeignResponse teacher) {
         //Если запись уже существует (safe_delete) восстанавливаем
         Optional<TeacherSubject> teacherSubjectOptional = teacherSubjectRepository
                 .findByIdWithDeleted(id.getSubjectId(), id.getTeacherId());

--- a/backend/academic-service/src/main/java/com/rusobr/academic/config/TransactionConfig.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/config/TransactionConfig.java
@@ -1,0 +1,21 @@
+package com.rusobr.academic.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration
+public class TransactionConfig {
+    @Bean
+    public TransactionTemplate readOnlyTransactionTemplate(PlatformTransactionManager transactionManager) {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setReadOnly(true);
+        return template;
+    }
+
+    @Bean
+    public TransactionTemplate writeTransactionTemplate(PlatformTransactionManager transactionManager) {
+        return new TransactionTemplate(transactionManager);
+    }
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/service/ClassStudentServiceTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/service/ClassStudentServiceTest.java
@@ -9,7 +9,6 @@ import com.rusobr.academic.infrastructure.persistence.repository.SchoolClassRepo
 import com.rusobr.academic.web.dto.feign.UserFeignResponse;
 import com.rusobr.academic.web.exception.ConflictException;
 import com.rusobr.academic.web.exception.NotFoundException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -17,7 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +24,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,16 +33,18 @@ class ClassStudentServiceTest {
     @Mock private SchoolClassRepository schoolClassRepository;
     @Mock private ClassStudentRepository classStudentRepository;
     @Mock private UserClient userClient;
-    @Mock private ClassStudentService self;
+    @Mock private TransactionTemplate transactionalTemplate;
 
     @InjectMocks private ClassStudentService service;
 
     private static final Long CLASS_ID = 1L;
     private static final Long STUDENT_ID = 42L;
 
-    @BeforeEach
-    void setUp() {
-        ReflectionTestUtils.setField(service, "self", self);
+    private void stubTransactionTemplateToExecuteCallback() {
+        lenient().when(transactionalTemplate.execute(any())).thenAnswer(invocation -> {
+            var callback = invocation.getArgument(0, org.springframework.transaction.support.TransactionCallback.class);
+            return callback.doInTransaction(null);
+        });
     }
 
     @Nested
@@ -72,28 +74,37 @@ class ClassStudentServiceTest {
     class AddStudent {
 
         @Test
-        @DisplayName("успешно проверяет студента во внешнем клиенте и делегирует вызов в транзакционный метод")
+        @DisplayName("успешно проверяет студента во внешнем клиенте и делегирует в транзакционный блок")
         void success() {
-            // В addStudent() сначала дергается feign-клиент, а затем метод через self-прокси
+            stubTransactionTemplateToExecuteCallback();
+            SchoolClass schoolClass = mock(SchoolClass.class);
+
             doNothing().when(userClient).existStudentById(STUDENT_ID);
+            when(schoolClassRepository.existsById(CLASS_ID)).thenReturn(true);
+            when(classStudentRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
+            when(schoolClassRepository.getReferenceById(CLASS_ID)).thenReturn(schoolClass);
 
             service.addStudent(CLASS_ID, STUDENT_ID);
 
             verify(userClient).existStudentById(STUDENT_ID);
-            verify(self).addStudentTransactional(CLASS_ID, STUDENT_ID);
+            verify(transactionalTemplate).execute(any());
+            verify(classStudentRepository).save(argThat(cs ->
+                    cs.getStudentId().equals(STUDENT_ID) && cs.getSchoolClass() == schoolClass));
         }
     }
 
     @Nested
-    @DisplayName("addStudentTransactional")
+    @DisplayName("addStudent — транзакционная логика")
     class AddStudentTransactional {
 
         @Test
         @DisplayName("школьный класс не найден — бросает NotFoundException")
         void classNotFound_throwsNotFoundException() {
+            stubTransactionTemplateToExecuteCallback();
+            doNothing().when(userClient).existStudentById(STUDENT_ID);
             when(schoolClassRepository.existsById(CLASS_ID)).thenReturn(false);
 
-            assertThatThrownBy(() -> service.addStudentTransactional(CLASS_ID, STUDENT_ID))
+            assertThatThrownBy(() -> service.addStudent(CLASS_ID, STUDENT_ID))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessageContaining("SchoolClass with id " + CLASS_ID + " not found");
 
@@ -104,10 +115,12 @@ class ClassStudentServiceTest {
         @Test
         @DisplayName("студент уже привязан к классу — бросает ConflictException")
         void studentAlreadyExists_throwsConflictException() {
+            stubTransactionTemplateToExecuteCallback();
+            doNothing().when(userClient).existStudentById(STUDENT_ID);
             when(schoolClassRepository.existsById(CLASS_ID)).thenReturn(true);
             when(classStudentRepository.existsByStudentId(STUDENT_ID)).thenReturn(true);
 
-            assertThatThrownBy(() -> service.addStudentTransactional(CLASS_ID, STUDENT_ID))
+            assertThatThrownBy(() -> service.addStudent(CLASS_ID, STUDENT_ID))
                     .isInstanceOf(ConflictException.class)
                     .hasMessageContaining("Student already exists in class");
 
@@ -118,13 +131,15 @@ class ClassStudentServiceTest {
         @Test
         @DisplayName("успешно находит класс, проверяет дубликаты и сохраняет студента в класс")
         void success() {
+            stubTransactionTemplateToExecuteCallback();
             SchoolClass schoolClass = mock(SchoolClass.class);
 
+            doNothing().when(userClient).existStudentById(STUDENT_ID);
             when(schoolClassRepository.existsById(CLASS_ID)).thenReturn(true);
             when(classStudentRepository.existsByStudentId(STUDENT_ID)).thenReturn(false);
             when(schoolClassRepository.getReferenceById(CLASS_ID)).thenReturn(schoolClass);
 
-            service.addStudentTransactional(CLASS_ID, STUDENT_ID);
+            service.addStudent(CLASS_ID, STUDENT_ID);
 
             verify(classStudentRepository).save(argThat(classStudent ->
                     classStudent.getStudentId().equals(STUDENT_ID) &&

--- a/backend/academic-service/src/test/java/com/rusobr/academic/service/FinalGradeServiceTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/service/FinalGradeServiceTest.java
@@ -21,6 +21,7 @@ import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeResponse;
 import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeTeacherResponse;
 import com.rusobr.academic.web.exception.ConflictException;
 import com.rusobr.academic.web.exception.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -51,6 +53,11 @@ class FinalGradeServiceTest {
     @Mock private UserClient userClient;
 
     @InjectMocks private FinalGradeService service;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(service, "self", service);
+    }
 
     private static final Long STUDENT_ID = 42L;
     private static final Long GRADE_ID = 100L;

--- a/backend/academic-service/src/test/java/com/rusobr/academic/service/JournalServiceTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/service/JournalServiceTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -54,6 +56,7 @@ class JournalServiceTest {
     @Mock private UserClient userClient;
     @Mock private LessonInstanceMapper lessonInstanceMapper;
     @Mock private AcademicPeriodService academicPeriodService;
+    @Mock private TransactionTemplate readOnlyTransactionTemplate;
 
     @InjectMocks private JournalService service;
 
@@ -63,6 +66,14 @@ class JournalServiceTest {
     private static final Long LESSON_INSTANCE_ID = 100L;
     private static final LocalDate START_DATE = LocalDate.of(2026, 9, 1);
     private static final LocalDate END_DATE = LocalDate.of(2026, 11, 30);
+
+    @SuppressWarnings("unchecked")
+    private void stubReadOnlyTransactionTemplate() {
+        lenient().when(readOnlyTransactionTemplate.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(null);
+        });
+    }
 
     @Nested
     @DisplayName("getGradesLessonsByStudentId")
@@ -113,6 +124,7 @@ class JournalServiceTest {
         @Test
         @DisplayName("успешно собирает журнал учителя и корректно считает средневзвешенный балл")
         void success() {
+            stubReadOnlyTransactionTemplate();
             AcademicPeriod period = AcademicPeriod.builder().startDate(START_DATE).endDate(END_DATE).build();
             AcademicPeriodResponse periodResponse = mock(AcademicPeriodResponse.class);
 

--- a/backend/academic-service/src/test/java/com/rusobr/academic/service/PeriodGradeServiceTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/service/PeriodGradeServiceTest.java
@@ -23,6 +23,7 @@ import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeResponse;
 import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeStudentResponse;
 import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeTeacherResponse;
 import com.rusobr.academic.web.exception.ConflictException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -55,6 +57,11 @@ class PeriodGradeServiceTest {
     @Mock private AcademicPeriodService academicPeriodService;
 
     @InjectMocks private PeriodGradeService service;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(service, "self", service);
+    }
 
     private static final Long STUDENT_ID = 42L;
     private static final Long ASSIGNMENT_ID = 7L;

--- a/backend/academic-service/src/test/java/com/rusobr/academic/service/TeacherSubjectServiceTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/service/TeacherSubjectServiceTest.java
@@ -15,6 +15,7 @@ import com.rusobr.academic.web.dto.teacherSubject.TeacherSubjectRequest;
 import com.rusobr.academic.web.dto.teacherSubject.TeacherSubjectResponse;
 import com.rusobr.academic.web.exception.ConflictException;
 import com.rusobr.academic.web.exception.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
 import java.util.List;
@@ -41,6 +43,11 @@ class TeacherSubjectServiceTest {
     @Mock private SubjectRepository subjectRepository;
 
     @InjectMocks private TeacherSubjectService service;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(service, "self", service);
+    }
 
     private static final Long TEACHER_ID = 5L;
     private static final Long SUBJECT_ID = 10L;

--- a/backend/user-service/src/main/java/com/rusobr/user/application/service/student/StudentService.java
+++ b/backend/user-service/src/main/java/com/rusobr/user/application/service/student/StudentService.java
@@ -24,6 +24,8 @@ import com.rusobr.user.web.dto.student.StudentWithClassResponse;
 import com.rusobr.user.web.dto.teacher.TeacherResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +46,10 @@ public class StudentService {
     private final TeacherService teacherService;
     private final ParentRepository parentRepository;
     private final UserMapper userMapper;
+
+    @Lazy
+    @Autowired
+    private StudentService self;
 
     @Transactional(readOnly = true)
     public BatchUserResponse getBatch(List<Long> ids) {
@@ -76,10 +82,8 @@ public class StudentService {
         return studentMapper.toStudentDetails(student);
     }
 
-    @Transactional(readOnly = true)
     public StudentWithClassResponse getWithClassById(Long id) {
-        Student student = studentRepository.findWithUserById(id)
-                .orElseThrow(() -> notFoundStudent(id));
+        Student student = self.getStudentTransactional(id);
         SchoolClassResponse schoolClass = academicClient.getSchoolClassByStudentId(student.getId());
         TeacherResponse teacher = teacherService.getWithUserById(schoolClass.classTeacherId());
 
@@ -87,13 +91,23 @@ public class StudentService {
     }
 
     @Transactional(readOnly = true)
-    public StudentInfoResponse getStudentInfoById(Long id) {
-        Student student = studentRepository.findStudentInfoById(id)
+    Student getStudentTransactional(Long id) {
+        return studentRepository.findWithUserById(id)
                 .orElseThrow(() -> notFoundStudent(id));
+    }
+
+    public StudentInfoResponse getStudentInfoById(Long id) {
+        Student student = self.getStudentInfoTransactional(id);
         SchoolClassResponse schoolClass = academicClient.getSchoolClassByStudentId(student.getId());
         TeacherResponse teacher = teacherService.getWithUserById(schoolClass.classTeacherId());
 
         return studentMapper.toStudentInfoResponse(student, schoolClass, teacher);
+    }
+
+    @Transactional(readOnly = true)
+    Student getStudentInfoTransactional(Long id) {
+        return studentRepository.findStudentInfoById(id)
+                .orElseThrow(() -> notFoundStudent(id));
     }
 
     public Optional<Student> findByIdWithDeleted(Long id) {

--- a/backend/user-service/src/test/java/com/rusobr/user/service/StudentServiceTest.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/service/StudentServiceTest.java
@@ -25,6 +25,7 @@ import com.rusobr.user.web.dto.teacher.TeacherResponse;
 import com.rusobr.user.web.dto.user.UserResponse;
 import com.rusobr.user.web.exception.ConflictException;
 import com.rusobr.user.web.exception.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -181,6 +183,11 @@ class StudentServiceTest {
     @Nested
     @DisplayName("getWithClassById")
     class GetWithClassById {
+
+        @BeforeEach
+        void setUp() {
+            ReflectionTestUtils.setField(service, "self", service);
+        }
 
         @Test
         @DisplayName("успешно возвращает StudentWithClassResponse с данными класса и учителя")


### PR DESCRIPTION
- Добавил в academic-service TransactionConfig с readOnly и write бинами TransactionTemplate

Измененные методы:
academic-service:
- ClassStudentService#addStudent
- FinalGradeService#getByAssignmentId
- GradeService#getDetail
- JournalService#getJournalByAssignment
- PeriodGradeService#getByAssignmentWithAverage
- SchoolClassService#findWithStudentsById

user-service:
- StudentService#getWithClassById
- TeacherSubjectService#create

Closes https://github.com/M8eight/dnevnik/issues/149