### PR TITLE
feat(cache): кеширование Caffeine + деградация user-service + security-фиксы

### DIFF
--- a/backend/academic-service/build.gradle
+++ b/backend/academic-service/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     implementation 'org.postgresql:postgresql'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'

--- a/backend/academic-service/src/main/java/com/rusobr/academic/AcademicServiceApplication.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/AcademicServiceApplication.java
@@ -2,6 +2,7 @@ package com.rusobr.academic;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -10,6 +11,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableDiscoveryClient
 @EnableFeignClients
 @EnableJpaAuditing
+@EnableCaching
 public class AcademicServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(AcademicServiceApplication.class, args);

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AcademicPeriodService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AcademicPeriodService.java
@@ -13,6 +13,8 @@ import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +37,7 @@ public class AcademicPeriodService {
                         AcademicExceptionCode.ACADEMIC_PERIOD_NOT_FOUND));
     }
 
+    @Cacheable(value = "academicPeriods", key = "#date")
     public AcademicPeriod getByDate(LocalDate date) {
         return academicPeriodRepository.findByDate(date)
                 .orElseThrow(() -> new NotFoundException("Academic period by date %s not found".formatted(date),
@@ -53,6 +56,7 @@ public class AcademicPeriodService {
         return academicPeriodMapper.toResponse(getWithAcademicYearOrThrow(id));
     }
 
+    @Cacheable(value = "academicPeriods", key = "#academicYearId")
     @Transactional(readOnly = true)
     public List<AcademicPeriodResponse> getAllByAcademicYear(Long academicYearId) {
         return academicPeriodRepository.findAllByAcademicYearIdOrderByStartDateAsc(academicYearId).stream()
@@ -60,6 +64,7 @@ public class AcademicPeriodService {
                 .toList();
     }
 
+    @CacheEvict(value = "academicPeriods", allEntries = true)
     @Transactional
     public void openPeriod(Long id) {
         AcademicPeriod academicPeriod = getWithAcademicYearOrThrow(id);
@@ -69,6 +74,7 @@ public class AcademicPeriodService {
         academicPeriod.open();
     }
 
+    @CacheEvict(value = "academicPeriods", allEntries = true)
     @Transactional
     public void closePeriod(Long id) {
         AcademicPeriod academicPeriod = getWithAcademicYearOrThrow(id);
@@ -78,6 +84,7 @@ public class AcademicPeriodService {
         academicPeriod.close();
     }
 
+    @CacheEvict(value = "academicPeriods", allEntries = true)
     @Transactional
     public AcademicPeriodResponse create(AcademicPeriodRequest request) {
         validateDates(request.startDate(), request.endDate());
@@ -91,6 +98,7 @@ public class AcademicPeriodService {
         return academicPeriodMapper.toResponse(academicPeriodRepository.save(period));
     }
 
+    @CacheEvict(value = "academicPeriods", allEntries = true)
     @Transactional
     public void update(Long id, AcademicPeriodUpdateRequest request) {
         AcademicPeriod academicPeriod = getWithAcademicYearOrThrow(id);
@@ -109,6 +117,7 @@ public class AcademicPeriodService {
         if (request.name() != null) academicPeriod.setName(request.name());
     }
 
+    @CacheEvict(value = "academicPeriods", allEntries = true)
     @Transactional
     public void delete(Long id) {
         AcademicPeriod academicPeriod = getWithAcademicYearOrThrow(id);

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AcademicYearService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AcademicYearService.java
@@ -9,6 +9,8 @@ import com.rusobr.academic.infrastructure.persistence.repository.AcademicYearRep
 import com.rusobr.academic.web.dto.academicYear.AcademicYearRequest;
 import com.rusobr.academic.web.dto.academicYear.AcademicYearResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +24,7 @@ public class AcademicYearService {
     private final AcademicYearRepository academicYearRepository;
     private final AcademicYearMapper academicYearMapper;
 
+    @Cacheable(value = "academicYears")
     @Transactional(readOnly = true)
     public List<AcademicYearResponse> getAll() {
         return academicYearRepository.findAllByOrderByStartDateDesc().stream()
@@ -34,6 +37,7 @@ public class AcademicYearService {
         return academicYearMapper.toResponse(findOrThrow(id));
     }
 
+    @CacheEvict(value = "academicYears", allEntries = true)
     @Transactional
     public AcademicYearResponse create(AcademicYearRequest request) {
         validateDates(request.startDate(), request.endDate());
@@ -41,6 +45,7 @@ public class AcademicYearService {
         return academicYearMapper.toResponse(academicYearRepository.save(academicYear));
     }
 
+    @CacheEvict(value = "academicYears", allEntries = true)
     @Transactional
     public void open(Long id) {
         AcademicYear academicYear = findOrThrow(id);
@@ -50,6 +55,7 @@ public class AcademicYearService {
         academicYear.open();
     }
 
+    @CacheEvict(value = "academicYears", allEntries = true)
     @Transactional
     public void close(Long id) {
         AcademicYear academicYear = findOrThrow(id);
@@ -59,6 +65,7 @@ public class AcademicYearService {
         academicYear.close();
     }
 
+    @CacheEvict(value = "academicYears", allEntries = true)
     @Transactional
     public AcademicYearResponse update(Long id, AcademicYearRequest request) {
         AcademicYear academicYear = findOrThrow(id);
@@ -80,6 +87,7 @@ public class AcademicYearService {
         return academicYearMapper.toResponse(academicYear);
     }
 
+    @CacheEvict(value = "academicYears", allEntries = true)
     @Transactional
     public void delete(Long id) {
         AcademicYear academicYear = findOrThrow(id);

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AttendanceService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AttendanceService.java
@@ -7,9 +7,10 @@ import com.rusobr.academic.domain.model.LessonInstance;
 import com.rusobr.academic.infrastructure.persistence.repository.AttendanceRepository;
 import com.rusobr.academic.web.dto.attendances.AttendanceRequest;
 import com.rusobr.academic.web.dto.attendances.AttendanceResponse;
-import com.rusobr.common.exception.ConflictException;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
+import com.rusobr.common.exception.ConflictException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +23,7 @@ public class AttendanceService {
     private final LessonInstanceService lessonInstanceService;
     private final AcademicPeriodService academicPeriodService;
 
+    @CacheEvict(value = {"journalByAssignment", "journalByStudentId"}, allEntries = true)
     @Transactional
     public AttendanceResponse create(AttendanceRequest attendanceRequest) {
         LessonInstance lessonInstance = lessonInstanceService.getById(attendanceRequest.lessonInstanceId());
@@ -44,6 +46,7 @@ public class AttendanceService {
         return attendanceMapper.toAttendanceResponse(attendanceRepository.save(attendance));
     }
 
+    @CacheEvict(value = {"journalByAssignment", "journalByStudentId"}, allEntries = true)
     @Transactional
     public void delete(Long id) {
         attendanceRepository.deleteById(id);

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/FinalGradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/FinalGradeService.java
@@ -62,6 +62,8 @@ public class FinalGradeService {
 
     public List<FinalGradeTeacherResponse> getByAssignmentId(Long teachingAssignmentId, Long academicYearId) {
         DbData data = self.getByAssignmentTransactional(teachingAssignmentId, academicYearId);
+    public FinalGradeTeacherResponse getByAssignmentId(Long teachingAssignmentId, Long academicYearId) {
+        DbData data = self.getByAssignmentIdTransactional(teachingAssignmentId, academicYearId);
         List<FinalGradeResponse> mappedFinalGrades = data.finalGrades().stream().map(finalGradeMapper::toFinalGradeResponse).toList();
         Map<Long, List<FinalGradeResponse>> finalGradesMap = mappedFinalGrades.stream().collect(Collectors.groupingBy(
                 FinalGradeResponse::studentId,
@@ -71,12 +73,14 @@ public class FinalGradeService {
 
         BatchUserResponse students = userClient.getBatchStudents(data.studentIds());
 
-        return students.found().stream().map(user ->
-                new FinalGradeTeacherResponse(user, finalGradesMap.get(user.id()))).toList();
+        List<StudentFinalGradesResponse> result = students.found().stream().map(user ->
+                new StudentFinalGradesResponse(user, finalGradesMap.getOrDefault(user.id(), List.of()))).toList();
+
+        return new FinalGradeTeacherResponse(result, students.degraded());
     }
 
     @Transactional
-    DbData getByAssignmentTransactional(Long teachingAssignmentId, Long academicYearId) {
+    DbData getByAssignmentIdTransactional(Long teachingAssignmentId, Long academicYearId) {
         List<FinalGrade> finalGrades = finalGradeRepository.findFinalGradesByTeachingAssignmentId(teachingAssignmentId, academicYearId);
         List<Long> studentIds = teachingAssignmentService.getStudentIdsByTeachingAssignmentId(teachingAssignmentId);
         return new DbData(finalGrades, studentIds);

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/FinalGradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/FinalGradeService.java
@@ -10,10 +10,7 @@ import com.rusobr.academic.infrastructure.persistence.repository.AcademicPeriodR
 import com.rusobr.academic.infrastructure.persistence.repository.AcademicYearRepository;
 import com.rusobr.academic.infrastructure.persistence.repository.FinalGradeRepository;
 import com.rusobr.academic.infrastructure.persistence.repository.TeachingAssignmentRepository;
-import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeCreateResponse;
-import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeRequest;
-import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeResponse;
-import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeTeacherResponse;
+import com.rusobr.academic.web.dto.grade.finalGrade.*;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.dto.BatchUserResponse;
 import com.rusobr.common.exception.ConflictException;
@@ -21,6 +18,8 @@ import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +48,7 @@ public class FinalGradeService {
     @Autowired
     private FinalGradeService self;
 
+    @Cacheable(value = "finalGradesByStudent", key = "#studentId + '#' + #academicYearId")
     @Transactional(readOnly = true)
     public Map<String, FinalGradeResponse> getByStudentId(Long studentId, Long academicYearId) {
         List<FinalGrade> finalGrades = finalGradeRepository.findFinalGradesByStudentId(studentId, academicYearId);
@@ -60,8 +60,7 @@ public class FinalGradeService {
                 ));
     }
 
-    public List<FinalGradeTeacherResponse> getByAssignmentId(Long teachingAssignmentId, Long academicYearId) {
-        DbData data = self.getByAssignmentTransactional(teachingAssignmentId, academicYearId);
+    @Cacheable(value = "finalGradesByAssignment", key = "#teachingAssignmentId + '#' + #academicYearId", unless = "#result.degradedUsers")
     public FinalGradeTeacherResponse getByAssignmentId(Long teachingAssignmentId, Long academicYearId) {
         DbData data = self.getByAssignmentIdTransactional(teachingAssignmentId, academicYearId);
         List<FinalGradeResponse> mappedFinalGrades = data.finalGrades().stream().map(finalGradeMapper::toFinalGradeResponse).toList();
@@ -86,6 +85,7 @@ public class FinalGradeService {
         return new DbData(finalGrades, studentIds);
     }
 
+    @CacheEvict(value = {"finalGradesByStudent", "finalGradesByAssignment"}, allEntries = true)
     @Transactional
     public FinalGradeCreateResponse create(FinalGradeRequest finalGradeRequest) {
 
@@ -112,6 +112,7 @@ public class FinalGradeService {
         return finalGradeMapper.toFinalGradeCreateResponse(finalGradeRepository.save(finalGrade));
     }
 
+    @CacheEvict(value = {"finalGradesByStudent", "finalGradesByAssignment"}, allEntries = true)
     @Transactional
     public void delete(Long id) {
         FinalGrade finalGrade = finalGradeRepository.findWithAcademicYearById(id)

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/GradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/GradeService.java
@@ -20,6 +20,8 @@ import com.rusobr.common.exception.ConflictException;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -50,6 +52,7 @@ public class GradeService {
         return gradeMapper.toGradeResponseDto(grade);
     }
 
+    @Cacheable(value = "gradesByPeriod", key = "#studentId + '#' + #date")
     @Transactional(readOnly = true)
     public Double getAverageByPeriod(Long studentId, LocalDate date) {
         AcademicPeriod academicPeriod = academicPeriodRepository.findByDate(date)
@@ -63,6 +66,7 @@ public class GradeService {
                 .doubleValue();
     }
 
+    @Cacheable(value = "gradesByDate", key = "#studentId + '#' + #date")
     @Transactional(readOnly = true)
     public List<GradeWithSubjectNameResponse> findAllByDate(Long studentId, LocalDate date) {
         return gradeRepository.findAllByDateAndStudentId(studentId, date).stream().map(gradeMapper::toWithSubjectNameResponse).toList();
@@ -77,6 +81,7 @@ public class GradeService {
         return gradeMapper.toGradeDetailResponse(gradeProjection, teacher);
     }
 
+    @CacheEvict(value = {"gradesByDate", "gradesByPeriod", "journalByAssignment", "journalByStudentId", "schedulesByStudentId"}, allEntries = true)
     @Transactional
     public CreateGradeResponse create(CreateGradeRequest gradeDto) {
         LessonInstance lessonInstance = lessonInstanceRepository.findById(gradeDto.lessonInstanceId())
@@ -95,6 +100,7 @@ public class GradeService {
                 gradeRepository.save(grade), lessonInstanceMapper.toLessonInstanceDto(lessonInstance));
     }
 
+    @CacheEvict(value = {"gradesByDate", "gradesByPeriod", "journalByAssignment", "journalByStudentId"}, allEntries = true)
     @Transactional
     public void delete(Long id) {
         Grade grade = gradeRepository.findWithLessonInstanceById(id)

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/HomeworkService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/HomeworkService.java
@@ -12,6 +12,8 @@ import com.rusobr.common.exception.ConflictException;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -29,17 +31,20 @@ public class HomeworkService {
     private final AcademicPeriodService academicPeriodService;
     private final LessonInstanceService lessonInstanceService;
 
+    @Cacheable(value = "homeworksByDate", key = "#studentId + '#' + #date")
     @Transactional(readOnly = true)
     public List<HomeworkWithSubjectResponse> getByDate(LocalDate date, Long studentId) {
         return homeworkRepository.findHomeworksByDate(date, studentId).stream().map(homeworkMapper::toWithSubjectResponse).toList();
     }
 
+    @Cacheable(value = "homeworksByAssignment", key = "#teachingAssignmentId")
     @Transactional(readOnly = true)
     public Page<HomeworkResponse> getByAssignment(Long teachingAssignmentId, Pageable pageable) {
         Page<Homework> homeworkPage = homeworkRepository.findHomeworksByTeachingAssignmentId(teachingAssignmentId, pageable);
         return homeworkPage.map(homeworkMapper::toHomeworkResponse);
     }
 
+    @CacheEvict(value = {"homeworksByDate", "homeworksByAssignment"}, allEntries = true)
     @Transactional
     public HomeworkResponse create(HomeworkRequest homeworkRequest) {
         LessonInstance lessonInstance = lessonInstanceService.getById(homeworkRequest.lessonInstanceId());
@@ -58,6 +63,7 @@ public class HomeworkService {
         return homeworkMapper.toHomeworkResponse(homeworkRepository.save(homework));
     }
 
+    @CacheEvict(value = {"homeworksByDate", "homeworksByAssignment"}, allEntries = true)
     @Transactional
     public void delete(Long id) {
         Homework homework = homeworkRepository.findWithLessonInstanceById(id)

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/JournalService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/JournalService.java
@@ -15,6 +15,7 @@ import com.rusobr.academic.web.dto.lessonInstance.teacher.GradeStudentDto;
 import com.rusobr.academic.web.dto.lessonInstance.teacher.StudentJournalDto;
 import com.rusobr.academic.web.dto.lessonInstance.teacher.TeacherJournalResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -47,6 +48,7 @@ public class JournalService {
             List<AttendanceStudentDto> attendances
     ) {}
 
+    @Cacheable(value = "journalByStudentId", key = "#studentId + '#' + #academicPeriodId")
     @Transactional(readOnly = true)
     public GradesLessonsResponse getGradesByStudentId(Long studentId, Long academicPeriodId) {
         //Получаем Academic period
@@ -85,6 +87,7 @@ public class JournalService {
         return new GradesLessonsResponse(academicPeriodMapper.toResponse(academicPeriod), dates, subjects);
     }
 
+    @Cacheable(value = "journalByAssignment", key = "#teachingAssignmentId + '#' + #academicPeriodId", unless = "#result.degradedStudents")
     public TeacherJournalResponse getJournalByAssignment(Long teachingAssignmentId, Long academicPeriodId) {
         JournalDbData data = Objects.requireNonNull(readOnlyTransactionTemplate.execute(status ->
                 fetchJournalData(teachingAssignmentId, academicPeriodId)));
@@ -157,6 +160,7 @@ public class JournalService {
                 : 0.0;
     }
 
+    @Cacheable(value = "lessonInstancesByAssignment", key = "#teachingAssignmentId + '#' + #academicPeriodId")
     public List<LessonInstanceDto> getInstancesByAssignment(Long teachingAssignmentId, Long academicPeriodId) {
         AcademicPeriod academicPeriod = academicPeriodService.getById(academicPeriodId);
 

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/JournalService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/JournalService.java
@@ -48,7 +48,7 @@ public class JournalService {
     ) {}
 
     @Transactional(readOnly = true)
-    public GradesLessonsResponse getGradesLessonsByStudentId(Long studentId, Long academicPeriodId) {
+    public GradesLessonsResponse getGradesByStudentId(Long studentId, Long academicPeriodId) {
         //Получаем Academic period
         AcademicPeriod academicPeriod = academicPeriodService.getById(academicPeriodId);
 
@@ -97,7 +97,8 @@ public class JournalService {
                 academicPeriodMapper.toResponse(data.academicPeriod()),
                 students,
                 data.lessonInstances(),
-                studentJournal
+                studentJournal,
+                students.degraded()
         );
     }
 

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/PeriodGradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/PeriodGradeService.java
@@ -72,14 +72,15 @@ public class PeriodGradeService {
     public List<PeriodGradeTeacherResponse> getByAssignmentWithAverage(Long teachingAssignmentId, Long currentAcademicPeriodId, Long academicYearId) {
         PeriodGradeDbData data = self.getByAssignmentWithAverageTransactional(teachingAssignmentId, currentAcademicPeriodId, academicYearId);
 
-        List<UserFeignResponse> students = userClient.getBatchStudents(data.studentIds()).found();
+        BatchUserResponse students = userClient.getBatchStudents(data.studentIds());
 
-        return students.stream()
-                .map(user -> new PeriodGradeTeacherResponse(
+        List<StudentPeriodGradeWithAverage> studentPeriodGrades = students.found().stream()
+                .map(user -> new StudentPeriodGradeWithAverage(
                         user,
                         data.periodGradesMap().get(user.id()),
                         data.averageGradesMap().get(user.id())
                 )).toList();
+        return new PeriodGradeTeacherResponse(studentPeriodGrades, students.degraded());
     }
 
     @Transactional(readOnly = true)

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/PeriodGradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/PeriodGradeService.java
@@ -9,17 +9,16 @@ import com.rusobr.academic.infrastructure.client.UserClient;
 import com.rusobr.academic.infrastructure.persistence.repository.GradeRepository;
 import com.rusobr.academic.infrastructure.persistence.repository.PeriodGradeRepository;
 import com.rusobr.academic.infrastructure.persistence.repository.TeachingAssignmentRepository;
-import com.rusobr.common.dto.UserFeignResponse;
 import com.rusobr.academic.web.dto.grade.StudentAverageDto;
-import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeRequest;
-import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeResponse;
-import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeStudentResponse;
-import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeTeacherResponse;
-import com.rusobr.common.exception.ConflictException;
+import com.rusobr.academic.web.dto.grade.periodGrade.*;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
+import com.rusobr.common.dto.BatchUserResponse;
+import com.rusobr.common.exception.ConflictException;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,6 +52,7 @@ public class PeriodGradeService {
     @Autowired
     private PeriodGradeService self;
 
+    @Cacheable(value = "periodGradesByStudentId", key = "#studentId + '#' + #academicYearId")
     @Transactional(readOnly = true)
     public Map<String, List<PeriodGradeStudentResponse>> getByStudentId(Long studentId, Long academicYearId) {
         List<PeriodGradeStudentResponse> periodGrades = periodGradeRepository
@@ -69,7 +69,9 @@ public class PeriodGradeService {
         );
     }
 
-    public List<PeriodGradeTeacherResponse> getByAssignmentWithAverage(Long teachingAssignmentId, Long currentAcademicPeriodId, Long academicYearId) {
+
+    @Cacheable(value = "periodGradesByAssignment", key = "#teachingAssignmentId + '#' + #currentAcademicPeriodId + '#' + #academicYearId")
+    public PeriodGradeTeacherResponse getByAssignmentWithAverage(Long teachingAssignmentId, Long currentAcademicPeriodId, Long academicYearId) {
         PeriodGradeDbData data = self.getByAssignmentWithAverageTransactional(teachingAssignmentId, currentAcademicPeriodId, academicYearId);
 
         BatchUserResponse students = userClient.getBatchStudents(data.studentIds());
@@ -103,6 +105,7 @@ public class PeriodGradeService {
         return new PeriodGradeDbData(studentIds, periodGradesMap, averageGradesMap);
     }
 
+    @CacheEvict(value = {"periodGradesByAssignment", "periodGradesByStudentId"}, allEntries = true)
     @Transactional
     public PeriodGradeResponse create(PeriodGradeRequest dto) {
         AcademicPeriod academicPeriod = academicPeriodService.getById(dto.academicPeriodId());
@@ -127,6 +130,7 @@ public class PeriodGradeService {
 
     }
 
+    @CacheEvict(value = {"periodGradesByAssignment", "periodGradesByStudentId"}, allEntries = true)
     @Transactional
     public void delete(Long periodGradeId) {
         PeriodGrade periodGrade = periodGradeRepository.findWithAcademicPeriodById(periodGradeId)

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/ScheduleService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/ScheduleService.java
@@ -17,6 +17,8 @@ import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,6 +49,7 @@ public class ScheduleService {
                 .stream().map(scheduleLessonMapper::toScheduleLessonResponse).toList();
     }
 
+    @Cacheable(value = "schedulesByStudentId", key = "#studentId + '#' + #startDate + '#' + #endDate")
     @Transactional(readOnly = true)
     public List<DiaryScheduleDto> getByStudentId(Long studentId, LocalDate startDate, LocalDate endDate) {
         //Получаем шаблон расписания по периоду и собираем их id в отдельный List
@@ -137,6 +140,7 @@ public class ScheduleService {
                 );
     }
 
+    @CacheEvict(value = "schedulesByStudentId", allEntries = true)
     public void create(ScheduleLessonRequest scheduleLessonRequest) {
         userClient.getTeacherById(scheduleLessonRequest.teacherId());
         self.createTransactional(scheduleLessonRequest);
@@ -177,6 +181,7 @@ public class ScheduleService {
         lessonInstanceService.generateInstanceForLesson(scheduleLesson);
     }
 
+    @CacheEvict(value = "schedulesByStudentId", allEntries = true)
     @Transactional
     public void close(Long scheduleId, LocalDate closeDate) {
         ScheduleLesson scheduleLesson = scheduleLessonRepository.findWithTeachingAssignmentById(scheduleId)

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/TeacherSubjectService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/TeacherSubjectService.java
@@ -15,6 +15,8 @@ import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +39,7 @@ public class TeacherSubjectService {
     @Autowired
     private TeacherSubjectService self;
 
+    @Cacheable("teacherSubjects")
     public List<TeacherSubjectResponse> findAll() {
         //Получаем учителей из базы academic потом идем в user-service и упаковываем в map, где ключ это id пользователя
         List<TeacherSubject> teacherSubjects = teacherSubjectRepository.findAll();
@@ -56,6 +59,7 @@ public class TeacherSubjectService {
         ).toList();
     }
 
+    @CacheEvict(value = "teacherSubjects", allEntries = true)
     public TeacherSubjectResponse create(TeacherSubjectRequest request) {
         TeacherSubjectId id = TeacherSubjectId.builder()
                 .teacherId(request.teacherId()).subjectId(request.subjectId()).build();
@@ -89,6 +93,7 @@ public class TeacherSubjectService {
         return teacherSubjectMapper.toResponse(teacherSubjectRepository.save(teacherSubject), teacher);
     }
 
+    @CacheEvict(value = "teacherSubjects", allEntries = true)
     @Transactional
     public void delete(TeacherSubjectRequest request) {
         TeacherSubjectId id = TeacherSubjectId.builder()

--- a/backend/academic-service/src/main/java/com/rusobr/academic/config/CacheConfig.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/config/CacheConfig.java
@@ -1,0 +1,45 @@
+package com.rusobr.academic.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Duration;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    @Primary
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofMinutes(10))
+                .maximumSize(500));
+
+        cacheManager.registerCustomCache("academicYears",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(Duration.ofHours(24))
+                        .maximumSize(500)
+                        .build());
+
+        cacheManager.registerCustomCache("academicPeriods",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(Duration.ofHours(6))
+                        .maximumSize(500)
+                        .build());
+
+        cacheManager.registerCustomCache("teacherSubjects",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(Duration.ofHours(6))
+                        .maximumSize(500)
+                        .build());
+
+        return cacheManager;
+    }
+
+}

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/FinalGradeController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/FinalGradeController.java
@@ -11,7 +11,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -29,8 +28,8 @@ public class FinalGradeController {
 
     @PreAuthorize("@gradeSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
     @GetMapping("/by-assignment")
-    public List<FinalGradeTeacherResponse> getByAssignmentId(@RequestParam Long teachingAssignmentId,
-                                                             @RequestParam Long academicYearId) {
+    public FinalGradeTeacherResponse getByAssignmentId(@RequestParam Long teachingAssignmentId,
+                                                       @RequestParam Long academicYearId) {
         return finalGradeService.getByAssignmentId(teachingAssignmentId, academicYearId);
     }
 

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/JournalController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/JournalController.java
@@ -25,7 +25,7 @@ public class JournalController {
     public GradesLessonsResponse getGradesByStudentId(@AuthenticationPrincipal Jwt jwt,
                                                       @RequestParam("academicPeriodId") Long academicPeriodId) {
         Long userId = jwt.getClaim("user_id");
-        return lessonInstanceService.getGradesLessonsByStudentId(userId, academicPeriodId);
+        return lessonInstanceService.getGradesByStudentId(userId, academicPeriodId);
     }
 
     @GetMapping("/journal/by-assignment")

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/JournalController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/JournalController.java
@@ -5,6 +5,7 @@ import com.rusobr.academic.web.dto.lessonInstance.GradesLessonsResponse;
 import com.rusobr.academic.web.dto.lessonInstance.LessonInstanceDto;
 import com.rusobr.academic.web.dto.lessonInstance.teacher.TeacherJournalResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,6 +29,7 @@ public class JournalController {
         return lessonInstanceService.getGradesByStudentId(userId, academicPeriodId);
     }
 
+    @PreAuthorize("@gradeSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
     @GetMapping("/journal/by-assignment")
     public TeacherJournalResponse getByAssignment(
             @RequestParam("teachingAssignmentId") Long teachingAssignmentId,
@@ -35,6 +37,7 @@ public class JournalController {
         return lessonInstanceService.getJournalByAssignment(teachingAssignmentId, academicPeriodId);
     }
 
+    @PreAuthorize("@gradeSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
     @GetMapping("/lesson-instances/by-assignment")
     public List<LessonInstanceDto> getInstanceByAssignment(@RequestParam("teachingAssignmentId") Long teachingAssignmentId,
                                                            @RequestParam("academicPeriodId") Long academicPeriodId) {

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/PeriodGradeController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/PeriodGradeController.java
@@ -25,9 +25,9 @@ public class PeriodGradeController {
     }
 
     @GetMapping("/by-assignment")
-    public List<PeriodGradeTeacherResponse> getGradesByAssignment(@RequestParam Long teachingAssignmentId,
-                                                                  @RequestParam Long currentAcademicPeriodId,
-                                                                  @RequestParam Long academicYearId) {
+    public PeriodGradeTeacherResponse getGradesByAssignment(@RequestParam Long teachingAssignmentId,
+                                                                     @RequestParam Long currentAcademicPeriodId,
+                                                                     @RequestParam Long academicYearId) {
         return periodGradeService.getByAssignmentWithAverage(teachingAssignmentId, currentAcademicPeriodId, academicYearId);
     }
 

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/PeriodGradeController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/PeriodGradeController.java
@@ -4,6 +4,7 @@ import com.rusobr.academic.application.service.PeriodGradeService;
 import com.rusobr.academic.web.dto.grade.periodGrade.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
@@ -24,6 +25,7 @@ public class PeriodGradeController {
         return periodGradeService.getByStudentId(userId, academicYearId);
     }
 
+    @PreAuthorize("@gradeSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
     @GetMapping("/by-assignment")
     public PeriodGradeTeacherResponse getGradesByAssignment(@RequestParam Long teachingAssignmentId,
                                                                      @RequestParam Long currentAcademicPeriodId,

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/ScheduleController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/ScheduleController.java
@@ -17,7 +17,7 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-@RequestMapping("/api/v1/")
+@RequestMapping("/api/v1")
 public class ScheduleController {
 
     private final ScheduleService scheduleService;

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/grade/finalGrade/FinalGradeTeacherResponse.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/grade/finalGrade/FinalGradeTeacherResponse.java
@@ -1,11 +1,9 @@
 package com.rusobr.academic.web.dto.grade.finalGrade;
 
-import com.rusobr.common.dto.UserFeignResponse;
-
 import java.util.List;
 
 public record FinalGradeTeacherResponse(
-        UserFeignResponse user,
-        List<FinalGradeResponse> finalGrades
+        List<StudentFinalGradesResponse> studentFinalGradesResponse,
+        boolean isDegradedUsers
 ) {
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/grade/finalGrade/StudentFinalGradesResponse.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/grade/finalGrade/StudentFinalGradesResponse.java
@@ -1,0 +1,11 @@
+package com.rusobr.academic.web.dto.grade.finalGrade;
+
+import com.rusobr.common.dto.UserFeignResponse;
+
+import java.util.List;
+
+public record StudentFinalGradesResponse(
+        UserFeignResponse user,
+        List<FinalGradeResponse> finalGrades
+) {
+}

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/grade/periodGrade/PeriodGradeTeacherResponse.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/grade/periodGrade/PeriodGradeTeacherResponse.java
@@ -1,12 +1,9 @@
 package com.rusobr.academic.web.dto.grade.periodGrade;
 
-import com.rusobr.common.dto.UserFeignResponse;
-
 import java.util.List;
 
 public record PeriodGradeTeacherResponse(
-        UserFeignResponse user,
-        List<PeriodGradeResponse> periodGrades,
-        Double currentAverage
+        List<StudentPeriodGradeWithAverage> studentPeriodGrades,
+        boolean isDegradedUsers
 ) {
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/grade/periodGrade/StudentPeriodGradeWithAverage.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/grade/periodGrade/StudentPeriodGradeWithAverage.java
@@ -1,0 +1,12 @@
+package com.rusobr.academic.web.dto.grade.periodGrade;
+
+import com.rusobr.common.dto.UserFeignResponse;
+
+import java.util.List;
+
+public record StudentPeriodGradeWithAverage(
+        UserFeignResponse user,
+        List<PeriodGradeResponse> periodGrades,
+        Double currentAverage
+) {
+}

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/lessonInstance/teacher/TeacherJournalResponse.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/lessonInstance/teacher/TeacherJournalResponse.java
@@ -10,5 +10,6 @@ public record TeacherJournalResponse(
         AcademicPeriodResponse academicPeriod,
         BatchUserResponse students,
         List<LessonInstanceDto> lessonInstances,
-        List<StudentJournalDto> studentsJournal
+        List<StudentJournalDto> studentsJournal,
+        boolean isDegradedStudents
 ) {}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/controller/FinalGradeControllerTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/controller/FinalGradeControllerTest.java
@@ -9,6 +9,7 @@ import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeCreateResponse;
 import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeRequest;
 import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeResponse;
 import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeTeacherResponse;
+import com.rusobr.academic.web.dto.grade.finalGrade.StudentFinalGradesResponse;
 import com.rusobr.common.exception.ConflictException;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.NotFoundException;
@@ -105,7 +106,7 @@ public class FinalGradeControllerTest {
         );
     }
 
-    private FinalGradeTeacherResponse buildTeacherResponse() {
+    private StudentFinalGradesResponse buildTeacherResponse() {
         UserFeignResponse user = new UserFeignResponse(
                 100L,
                 "Ivan",
@@ -113,7 +114,7 @@ public class FinalGradeControllerTest {
                 "ipetrov",
                 "keycloak-123"
         );
-        return new FinalGradeTeacherResponse(user, List.of(buildGradeResponse()));
+        return new StudentFinalGradesResponse(user, List.of(buildGradeResponse()));
     }
 
     @Test
@@ -136,16 +137,16 @@ public class FinalGradeControllerTest {
     @DisplayName("GET /final-grades/by-assignment — 200 and list response")
     void getByAssignmentId_ShouldReturn200() throws Exception {
         when(finalGradeService.getByAssignmentId(TEACHING_ASSIGNMENT_ID, 1L))
-                .thenReturn(List.of(buildTeacherResponse()));
+                .thenReturn(new FinalGradeTeacherResponse(List.of(buildTeacherResponse()), false));
 
         mockMvc.perform(get("/api/v1/final-grades/by-assignment")
                         .param("teachingAssignmentId", String.valueOf(TEACHING_ASSIGNMENT_ID))
                         .param("academicYearId", String.valueOf(1L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].user.id").value(100L))
-                .andExpect(jsonPath("$[0].user.firstName").value("Ivan"))
-                .andExpect(jsonPath("$[0].finalGrades[0].id").value(FINAL_GRADE_ID))
-                .andExpect(jsonPath("$[0].finalGrades[0].subjectName").value("Mathematics"));
+                .andExpect(jsonPath("$.studentFinalGradesResponse[0].user.id").value(100L))
+                .andExpect(jsonPath("$.studentFinalGradesResponse[0].user.firstName").value("Ivan"))
+                .andExpect(jsonPath("$.studentFinalGradesResponse[0].finalGrades[0].id").value(FINAL_GRADE_ID))
+                .andExpect(jsonPath("$.studentFinalGradesResponse[0].finalGrades[0].subjectName").value("Mathematics"));
     }
 
     @Test

--- a/backend/academic-service/src/test/java/com/rusobr/academic/controller/JournalControllerTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/controller/JournalControllerTest.java
@@ -97,14 +97,14 @@ public class JournalControllerTest {
                 5.0,
                 List.of()
         );
-        return new TeacherJournalResponse(buildAcademicPeriodResponse(), new BatchUserResponse(List.of(student), List.of(), false), List.of(lessonInstance), List.of(studentJournal));
+        return new TeacherJournalResponse(buildAcademicPeriodResponse(), new BatchUserResponse(List.of(student), List.of(), false), List.of(lessonInstance), List.of(studentJournal), false);
     }
 
     @Test
     @DisplayName("GET /grades/by-student — 200 and grades lessons response")
     void getGradesByStudentId_ShouldReturn200() throws Exception {
         GradesLessonsResponse response = buildGradesLessonsResponse();
-        when(lessonInstanceService.getGradesLessonsByStudentId(STUDENT_ID, PERIOD_ID)).thenReturn(response);
+        when(lessonInstanceService.getGradesByStudentId(STUDENT_ID, PERIOD_ID)).thenReturn(response);
 
         mockMvc.perform(get("/api/v1/grades/by-student")
                         .param("academicPeriodId", String.valueOf(PERIOD_ID)))
@@ -119,7 +119,7 @@ public class JournalControllerTest {
     @Test
     @DisplayName("GET /grades/by-student — 404 when period not found")
     void getGradesByStudentId_ShouldReturn404_WhenPeriodNotFound() throws Exception {
-        when(lessonInstanceService.getGradesLessonsByStudentId(STUDENT_ID, PERIOD_ID))
+        when(lessonInstanceService.getGradesByStudentId(STUDENT_ID, PERIOD_ID))
                 .thenThrow(new NotFoundException("Academic period with id " + PERIOD_ID + " not found", AcademicExceptionCode.ACADEMIC_PERIOD_NOT_FOUND));
 
         mockMvc.perform(get("/api/v1/grades/by-student")

--- a/backend/academic-service/src/test/java/com/rusobr/academic/controller/PeriodGradeControllerTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/controller/PeriodGradeControllerTest.java
@@ -8,6 +8,7 @@ import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeRequest;
 import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeResponse;
 import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeStudentResponse;
 import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeTeacherResponse;
+import com.rusobr.academic.web.dto.grade.periodGrade.StudentPeriodGradeWithAverage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -78,8 +79,8 @@ public class PeriodGradeControllerTest {
         return new UserFeignResponse(STUDENT_ID, "Ivan", "Petrov", "ipetrov", "keycloak-1");
     }
 
-    private PeriodGradeTeacherResponse buildTeacherResponse() {
-        return new PeriodGradeTeacherResponse(
+    private StudentPeriodGradeWithAverage buildTeacherResponse() {
+        return new StudentPeriodGradeWithAverage(
                 buildUserFeignResponse(),
                 List.of(buildPeriodGradeResponse()),
                 4.75
@@ -103,16 +104,16 @@ public class PeriodGradeControllerTest {
     @DisplayName("GET /period-grades/by-assignment — 200 and teacher period grades list")
     void getGradesByAssignment_ShouldReturn200() throws Exception {
         when(periodGradeService.getByAssignmentWithAverage(TEACHING_ASSIGNMENT_ID, ACADEMIC_PERIOD_ID, 1L))
-                .thenReturn(List.of(buildTeacherResponse()));
+                .thenReturn(new PeriodGradeTeacherResponse(List.of(buildTeacherResponse()), false));
 
         mockMvc.perform(get("/api/v1/period-grades/by-assignment")
                         .param("teachingAssignmentId", String.valueOf(TEACHING_ASSIGNMENT_ID))
                         .param("currentAcademicPeriodId", String.valueOf(ACADEMIC_PERIOD_ID))
                         .param("academicYearId", String.valueOf(1L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].user.id").value(STUDENT_ID))
-                .andExpect(jsonPath("$[0].periodGrades[0].id").value(PERIOD_GRADE_ID))
-                .andExpect(jsonPath("$[0].currentAverage").value(4.75));
+                .andExpect(jsonPath("$.studentPeriodGrades[0].user.id").value(STUDENT_ID))
+                .andExpect(jsonPath("$.studentPeriodGrades[0].periodGrades[0].id").value(PERIOD_GRADE_ID))
+                .andExpect(jsonPath("$.studentPeriodGrades[0].currentAverage").value(4.75));
     }
 
     @Test

--- a/backend/academic-service/src/test/java/com/rusobr/academic/service/FinalGradeServiceTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/service/FinalGradeServiceTest.java
@@ -19,6 +19,7 @@ import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeCreateResponse;
 import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeRequest;
 import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeResponse;
 import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeTeacherResponse;
+import com.rusobr.academic.web.dto.grade.finalGrade.StudentFinalGradesResponse;
 import com.rusobr.common.exception.ConflictException;
 import com.rusobr.common.exception.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -116,11 +117,12 @@ class FinalGradeServiceTest {
             when(teachingAssignmentService.getStudentIdsByTeachingAssignmentId(ASSIGNMENT_ID)).thenReturn(List.of(STUDENT_ID));
             when(userClient.getBatchStudents(List.of(STUDENT_ID))).thenReturn(new BatchUserResponse(List.of(student), List.of(), false));
 
-            List<FinalGradeTeacherResponse> result = service.getByAssignmentId(ASSIGNMENT_ID, ACADEMIC_YEAR_ID);
+            FinalGradeTeacherResponse result = service.getByAssignmentId(ASSIGNMENT_ID, ACADEMIC_YEAR_ID);
 
-            assertThat(result).isNotNull().hasSize(1);
-            assertThat(result.get(0).user()).isEqualTo(student);
-            assertThat(result.get(0).finalGrades()).containsExactly(response);
+            assertThat(result).isNotNull();
+            assertThat(result.studentFinalGradesResponse()).hasSize(1);
+            assertThat(result.studentFinalGradesResponse().get(0).user()).isEqualTo(student);
+            assertThat(result.studentFinalGradesResponse().get(0).finalGrades()).containsExactly(response);
         }
     }
 

--- a/backend/academic-service/src/test/java/com/rusobr/academic/service/JournalServiceTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/service/JournalServiceTest.java
@@ -97,7 +97,7 @@ class JournalServiceTest {
                     .thenReturn(dates);
             when(academicPeriodMapper.toResponse(period)).thenReturn(periodResponse);
 
-            GradesLessonsResponse result = service.getGradesLessonsByStudentId(STUDENT_ID, PERIOD_ID);
+            GradesLessonsResponse result = service.getGradesByStudentId(STUDENT_ID, PERIOD_ID);
 
             assertThat(result).isNotNull();
             assertThat(result.dates()).isEqualTo(dates);
@@ -111,7 +111,7 @@ class JournalServiceTest {
             when(academicPeriodService.getById(PERIOD_ID))
                     .thenThrow(new NotFoundException("Academic period with id " + PERIOD_ID + " not found", null));
 
-            assertThatThrownBy(() -> service.getGradesLessonsByStudentId(STUDENT_ID, PERIOD_ID))
+            assertThatThrownBy(() -> service.getGradesByStudentId(STUDENT_ID, PERIOD_ID))
                     .isInstanceOf(NotFoundException.class);
         }
     }

--- a/backend/academic-service/src/test/java/com/rusobr/academic/service/PeriodGradeServiceTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/service/PeriodGradeServiceTest.java
@@ -21,6 +21,7 @@ import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeRequest;
 import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeResponse;
 import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeStudentResponse;
 import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeTeacherResponse;
+import com.rusobr.academic.web.dto.grade.periodGrade.StudentPeriodGradeWithAverage;
 import com.rusobr.common.exception.ConflictException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -141,11 +142,11 @@ class PeriodGradeServiceTest {
             when(gradeMapper.toStudentAverageDto(avgProjection)).thenReturn(avgDto);
 
             // When
-            List<PeriodGradeTeacherResponse> result = service.getByAssignmentWithAverage(ASSIGNMENT_ID, PERIOD_ID, ACADEMIC_YEAR_ID);
+            PeriodGradeTeacherResponse result = service.getByAssignmentWithAverage(ASSIGNMENT_ID, PERIOD_ID, ACADEMIC_YEAR_ID);
 
             // Then
-            assertThat(result).hasSize(1);
-            PeriodGradeTeacherResponse teacherResponse = result.get(0);
+            assertThat(result.studentPeriodGrades()).hasSize(1);
+            StudentPeriodGradeWithAverage teacherResponse = result.studentPeriodGrades().get(0);
             assertThat(teacherResponse.user()).isEqualTo(user);
             assertThat(teacherResponse.periodGrades()).containsExactly(pgResponse);
             assertThat(teacherResponse.currentAverage()).isEqualTo(4.75);

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -14,6 +14,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     annotationProcessor "org.hibernate.orm:hibernate-jpamodelgen:"
 
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/backend/user-service/src/main/java/com/rusobr/user/UserServiceApplication.java
+++ b/backend/user-service/src/main/java/com/rusobr/user/UserServiceApplication.java
@@ -2,6 +2,7 @@ package com.rusobr.user;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -10,6 +11,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableDiscoveryClient
 @EnableJpaAuditing
 @EnableFeignClients
+@EnableCaching
 public class UserServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(UserServiceApplication.class, args);

--- a/backend/user-service/src/main/java/com/rusobr/user/application/service/student/StudentService.java
+++ b/backend/user-service/src/main/java/com/rusobr/user/application/service/student/StudentService.java
@@ -25,6 +25,7 @@ import com.rusobr.user.web.dto.teacher.TeacherResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
@@ -82,6 +83,7 @@ public class StudentService {
         return studentMapper.toStudentDetails(student);
     }
 
+    @Cacheable(value = "studentHomeInfo", key = "#id")
     public StudentWithClassResponse getWithClassById(Long id) {
         Student student = self.getStudentTransactional(id);
         SchoolClassResponse schoolClass = academicClient.getSchoolClassByStudentId(student.getId());

--- a/backend/user-service/src/main/java/com/rusobr/user/config/CacheConfig.java
+++ b/backend/user-service/src/main/java/com/rusobr/user/config/CacheConfig.java
@@ -1,0 +1,31 @@
+package com.rusobr.user.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofMinutes(5))
+                .maximumSize(500));
+
+        cacheManager.registerCustomCache("studentHomeInfo",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(Duration.ofHours(24))
+                        .maximumSize(500)
+                        .build());
+
+        return cacheManager;
+    }
+
+}

--- a/frontend/src/hooks/use-final-grade.ts
+++ b/frontend/src/hooks/use-final-grade.ts
@@ -11,7 +11,7 @@ export const useFinalGradesByStudent = ( academicYearId: number ) => {
 };
 
 export const useFinalGradesByAssignment = ( teachingAssignmentId: number, academicYearId: number ) => {
-  return useQuery<FinalGradeTeacherResponse[]>({
+  return useQuery<FinalGradeTeacherResponse>({
     queryKey: ["finalGrades", teachingAssignmentId, academicYearId],
     queryFn: () => getFinalGradesByAssignment(teachingAssignmentId, academicYearId),
     enabled: !!teachingAssignmentId && !!academicYearId,

--- a/frontend/src/hooks/use-period-grade.ts
+++ b/frontend/src/hooks/use-period-grade.ts
@@ -18,7 +18,7 @@ export const usePeriodGradesByStudent = (academicYearId: number) => {
 };
 
 export const usePeriodGradesByAssignment = (teachingAssignmentId: number, currentAcademicPeriodId: number, academicYearId: number) => {
-  return useQuery<PeriodGradeTeacherResponse[]>({
+  return useQuery<PeriodGradeTeacherResponse>({
     queryKey: ["periodGrades", teachingAssignmentId, currentAcademicPeriodId, academicYearId],
     queryFn: () => getPeriodGradesByAssignment(teachingAssignmentId, currentAcademicPeriodId, academicYearId),
     enabled: !!teachingAssignmentId && !!currentAcademicPeriodId && !!academicYearId,

--- a/frontend/src/services/final-grade-service.ts
+++ b/frontend/src/services/final-grade-service.ts
@@ -10,9 +10,14 @@ export interface FinalGradeResponse {
     subjectName: string;
 }
 
-export interface FinalGradeTeacherResponse {
+export interface StudentFinalGradesResponse {
     user: UserSimpleResponse;
     finalGrades: FinalGradeResponse[];
+}
+
+export interface FinalGradeTeacherResponse {
+    studentFinalGradesResponse: StudentFinalGradesResponse[];
+    isDegradedUsers: boolean;
 }
 
 export interface FinalGradeCreateResponse {
@@ -44,8 +49,8 @@ export const getFinalGradesByStudent = async (academicYearId: number): Promise<F
     return data;
 };
 
-export const getFinalGradesByAssignment = async (teachingAssignmentId: number, academicYearId: number): Promise<FinalGradeTeacherResponse[]> => {
-    const { data } = await api.get<FinalGradeTeacherResponse[]>(
+export const getFinalGradesByAssignment = async (teachingAssignmentId: number, academicYearId: number): Promise<FinalGradeTeacherResponse> => {
+    const { data } = await api.get<FinalGradeTeacherResponse>(
         `/academic-service/api/v1/final-grades/by-assignment`, {
             params: {
                 teachingAssignmentId,

--- a/frontend/src/services/period-grade-service.ts
+++ b/frontend/src/services/period-grade-service.ts
@@ -10,6 +10,11 @@ export interface PeriodGradeStudentResponse {
 }
 
 export interface PeriodGradeTeacherResponse {
+    studentPeriodGrades: StudentPeriodGradeWithAverage[];
+    isDegradedUsers: boolean;
+}
+
+export interface StudentPeriodGradeWithAverage {
     user: UserSimpleResponse;
     periodGrades: PeriodGradeResponse[];
     currentAverage: number | null;
@@ -44,8 +49,8 @@ export const getPeriodGradesByStudent = async (academicYearId: number): Promise<
     return data;
 };
 
-export const getPeriodGradesByAssignment = async (teachingAssignmentId: number, currentAcademicPeriodId: number, academicYearId: number): Promise<PeriodGradeTeacherResponse[]> => {
-    const { data } = await api.get<PeriodGradeTeacherResponse[]>(
+export const getPeriodGradesByAssignment = async (teachingAssignmentId: number, currentAcademicPeriodId: number, academicYearId: number): Promise<PeriodGradeTeacherResponse> => {
+    const { data } = await api.get<PeriodGradeTeacherResponse>(
         `/academic-service/api/v1/period-grades/by-assignment`, {
         params: {
             teachingAssignmentId,

--- a/frontend/src/services/teacher-journal-service.ts
+++ b/frontend/src/services/teacher-journal-service.ts
@@ -49,6 +49,7 @@ export interface TeacherJournalResponse {
     students: BatchUserResponse;
     lessonInstances: LessonInstanceDto[];
     studentsJournal: StudentJournalEntry[];
+    isDegradedStudents: boolean;
 }
 
 export const getTeacherJournal = async (

--- a/frontend/src/views/index.tsx
+++ b/frontend/src/views/index.tsx
@@ -26,37 +26,13 @@ export default function Index() {
     }, [navigate, roles]);
 
     return (
-        <div>
-            <div>
-                <a href="/student/home">Домашняя страница ученика</a>
+        <>
+            <div className="min-h-screen flex items-center justify-center">
+                <div className="text-center">
+                    <p className="text-lg">Перенаправление...</p>
+                </div>
             </div>
-            <div>
-                <a href="/student/diary">Страница дневник ученика</a>
-            </div>
-            <div>
-                <a href="/student/grades">Страница оценок ученика</a>
-            </div>
-            <br />
-            <div>
-                <a href="/teacher/journal">Страница успеваемости учеников для учителя</a>
-            </div>
-            <div>
-                <a href="/teacher/homework">Страница с дз для учителя</a>
-            </div>
-            <br />
-            <div>
-                <a href="/admin/subject">Модификация предметов админ</a>
-            </div>
-            <div>
-                <a href="/admin/period">Модификация четвертей админ</a>
-            </div>
-            <div>
-                <a href="/admin/user">Модификация пользователей админ</a>
-            </div>
-            <div>
-                <a href="/admin/schedule">Модификация расписания админ</a>
-            </div>
-        </div>
+        </>
 
     );
 }

--- a/frontend/src/views/teacher/TeacherJournal.tsx
+++ b/frontend/src/views/teacher/TeacherJournal.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
-import { BookOpen, Users, BookCheck, Scale, CalendarDays, Lock, CalendarClock } from "lucide-react";
+import { BookOpen, Users, BookCheck, Scale, CalendarDays, Lock, CalendarClock, AlertTriangle } from "lucide-react";
 import { useTeacherJournal } from "@/hooks/use-teacher-journal";
 import { useTeachingAssignmentDetail } from "@/hooks/use-teaching-assignment";
 import { useGetAcademicPeriodsByAcademicYear } from "@/hooks/use-academic-period";
@@ -257,6 +257,15 @@ export default function TeacherJournal() {
               periodName={currentSelectedPeriod?.name}
               yearName={currentAcademicYear?.name}
             />
+          )}
+
+          {data?.isDegradedStudents && (
+            <div className="flex items-center gap-3 rounded-2xl px-5 py-3.5 mb-6 bg-(--red-light)/60 ring-1 ring-(--red)/10">
+              <AlertTriangle className="w-5 h-5 text-(--red) shrink-0" />
+              <p className="text-[13px] font-bold text-(--navy)">
+                Список учеников может быть неполным: сервис данных временно работает в ограниченном режиме.
+              </p>
+            </div>
           )}
 
 

--- a/frontend/src/views/teacher/TeacherJournalFinalGradeTab.tsx
+++ b/frontend/src/views/teacher/TeacherJournalFinalGradeTab.tsx
@@ -28,33 +28,40 @@ export default function FinalGradesView({
   students: Student[];
   currentAcademicPeriodId: number;
 }) {
-  const { data: finalGradesData = [], isLoading: isFinalLoading } =
+  const { data: finalGradesResponse, isLoading: isFinalLoading } =
     useFinalGradesByAssignment(teachingAssignmentId, academicYearId);
 
-  const { data: periodEntries = [], isLoading: isPeriodLoading } =
-    usePeriodGradesByAssignment(teachingAssignmentId, currentAcademicPeriodId, academicYearId);
-
+  const { data: response, isLoading: isEntriesLoading } = usePeriodGradesByAssignment(
+    teachingAssignmentId,
+    currentAcademicPeriodId,
+    academicYearId
+  );
+  const entries = useMemo(() => response?.studentPeriodGrades ?? [], [response?.studentPeriodGrades]);
+    
   const { data: academicPeriods = [] } = useGetAcademicPeriods();
 
-  const isLoading = isFinalLoading || isPeriodLoading;
+  const isLoading = isFinalLoading || isEntriesLoading;
   const totalCols = 1 + academicPeriods.length + 1 + 1;
 
   const finalGradeByStudentId = useMemo(() => {
     const map = new Map<number, FinalGradeResponse>();
-    if (finalGradesData && Array.isArray(finalGradesData)) {
-      finalGradesData.forEach((item) => {
+    const studentFinalGradesResponse = finalGradesResponse?.studentFinalGradesResponse ?? [];
+
+    if (studentFinalGradesResponse && Array.isArray(studentFinalGradesResponse)) {
+      studentFinalGradesResponse.forEach((item) => {
         if (item.finalGrades && item.finalGrades.length > 0) {
           map.set(item.user.id, item.finalGrades[0]);
         }
       });
     }
+
     return map;
-  }, [finalGradesData]);
+  }, [finalGradesResponse]);
 
   const periodGradeMap = useMemo(() => {
     const map = new Map<number, Map<number, PeriodGradeResponse>>();
-    if (periodEntries && Array.isArray(periodEntries)) {
-      periodEntries.forEach((entry) => {
+    if (entries && Array.isArray(entries)) {
+      entries.forEach((entry) => {
         const byPeriod = new Map<number, PeriodGradeResponse>();
         if (entry.periodGrades && Array.isArray(entry.periodGrades)) {
           entry.periodGrades.forEach((pg) => {
@@ -67,7 +74,7 @@ export default function FinalGradesView({
       });
     }
     return map;
-  }, [periodEntries]);
+  }, [entries]);
 
   const getPeriodAverage = (studentId: number): number | null => {
     const byPeriod = periodGradeMap.get(studentId);

--- a/frontend/src/views/teacher/TeacherJournalPeriodTab.tsx
+++ b/frontend/src/views/teacher/TeacherJournalPeriodTab.tsx
@@ -26,11 +26,12 @@ export default function PeriodGradesView({
   academicPeriodId,
   academicYearId,
 }: PeriodGradesViewProps) {
-  const { data: entries = [], isLoading: isEntriesLoading } = usePeriodGradesByAssignment(
+  const { data: response, isLoading: isEntriesLoading } = usePeriodGradesByAssignment(
     teachingAssignmentId,
     academicPeriodId,
     academicYearId
   );
+  const entries = useMemo(() => response?.studentPeriodGrades ?? [], [response?.studentPeriodGrades]);
 
   const { data: academicPeriods = [], isLoading: isPeriodsLoading } = useGetAcademicPeriods();
 


### PR DESCRIPTION
Внедрил in-memory кеширование через Caffeine, настроил TTL в CacheConfig
каждого сервиса.

выбрал caffeine так как на данный момент нет смысла во внешних сервисах типо redis и нету такого объема и потенциальной нагрузки, единственный плюс был бы в кешировании и инвалидации между сервисами но я решил выбрать in-memory кеш

user-service:
  - GET /api/v1/students/with-class — ttl 24ч (home страница student)

academic-service:
  - HomeworkService#getByDate, GradeService#getAverageByPeriod,
    GradeService#findAllByDate — ttl 10м (home страница student)
  - GET /api/v1/teacher-subjects/**       — ttl 6ч  (редко меняются)
  - GET /api/v1/academic-periods/**       — ttl 6ч  (редко меняются)
  - GET /api/v1/academic-years/**         — ttl 24ч (редко меняются)
  - GET /api/v1/schedules/diary           — ttl 10м
  - GET /api/v1/homeworks/by-assignment   — ttl 10м
  - GET /api/v1/final-grades/**           — ttl 10м
  - GET /api/v1/grades/by-student         — ttl 10м
  - GET /api/v1/journal/by-assignment     — ttl 10м
  - GET /api/v1/lesson-instances/by-assignment — ttl 10м

fix(security): добавил @PreAuthorize в контроллеры оценок и журнала
Закрыл доступ в PeriodGradeController#getGradesByAssignment,
JournalController#getByAssignment, JournalController#getInstanceByAssignment.

feat(resilience): деградация при недоступности user-service
Добавил флаг isDegradedUsers в batch-ответы (final-grades/getByAssignmentId,
journal/getJournalByAssignment) на фронте добавил alert
о недоступности user-service.

Closes #148