### PR TITLE
feat(observability): Настроил логирование, трассировку и метрики микросервисов

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,8 +20,8 @@ COPY common common
 COPY ${SERVICE_NAME} ${SERVICE_NAME}
 
 # Собираем JAR конкретного модуля
-RUN --mount=type=cache,id=gradle-cache,target=/home/gradle/.gradle/caches \
-    --mount=type=cache,id=gradle-wrapper,target=/home/gradle/.gradle/wrapper \
+RUN --mount=type=cache,id=gradle-cache,target=/home/gradle/.gradle/caches,sharing=locked \
+    --mount=type=cache,id=gradle-wrapper,target=/home/gradle/.gradle/wrapper,sharing=locked \
     ./gradlew :${SERVICE_NAME}:bootJar --no-daemon
 
 # --- Финальная стадия (Runtime Stage) ---

--- a/backend/academic-service/build.gradle
+++ b/backend/academic-service/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.github.openfeign:feign-micrometer'
+    implementation 'io.micrometer:context-propagation'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/config/security/SecurityConfig.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/config/security/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
                 .cors(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(req -> {
                     req
-                            .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll().requestMatchers("/public/**", "/actuator/health").permitAll()
+                            .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll().requestMatchers("/public/**", "/actuator/**").permitAll()
                             .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                             .requestMatchers(GET, "/api/v1/academic-years").hasAnyRole(STUDENT.name(), TEACHER.name(), PARENT.name(), ADMIN.name())
                             .requestMatchers(GET, "/api/v1/academic-periods").hasAnyRole(STUDENT.name(), TEACHER.name(), PARENT.name(), ADMIN.name())

--- a/backend/academic-service/src/main/resources/application.yml
+++ b/backend/academic-service/src/main/resources/application.yml
@@ -49,6 +49,8 @@ eureka:
       defaultZone: ${EUREKA_URL:http://user:password@localhost:8761/eureka/}
 
 logging:
+  file:
+    path: ${LOGS_PATH:./logs}
   loki:
     url: ${LOKI_URL:http://localhost:3100}/loki/api/v1/push}
   level:
@@ -82,13 +84,23 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,circuitbreakers,circuitbreakerevents,metrics
+        include: health, circuitbreakers, circuitbreakerevents, metrics, prometheus
+  endpoint:
+    health:
+      show-details: never
   health:
     circuitbreakers:
       enabled: true
   tracing:
     sampling:
       probability: 1.0
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+        http.client.requests: true
+  tag:
+    application: ${spring.application.name}
 
 keycloak:
   url: ${KC_URL:http://localhost:9090}

--- a/backend/academic-service/src/main/resources/logback-spring.xml
+++ b/backend/academic-service/src/main/resources/logback-spring.xml
@@ -1,48 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="academic-service"/>
+    <springProperty scope="context" name="logPath" source="logging.file.path" defaultValue="/app/logs"/>
 
-    <!-- Console Appender -->
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
+    <include resource="logback-include.xml"/>
 
-    <!-- File Appender для Alloy -->
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/app/logs/${appName}.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/app/logs/${appName}-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>100MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <maxHistory>7</maxHistory>
-        </rollingPolicy>
-
-        <!-- JSON формат для легкого парсинга -->
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <customFields>{"app":"${appName}"}</customFields>
-        </encoder>
-    </appender>
-
-    <!-- Async wrapper для FILE -->
-    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="FILE"/>
-        <queueSize>1000</queueSize>
-        <discardingThreshold>0</discardingThreshold>
-    </appender>
-
-    <root level="INFO">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="ASYNC_FILE"/>
-    </root>
-
-    <!-- Настройка уровней -->
-    <logger name="org.springframework.web.client.RestTemplate" level="INFO"/>
-    <logger name="com.netflix.discovery" level="WARN"/>
-    <logger name="com.netflix.eureka" level="WARN"/>
-    <logger name="org.springframework.web" level="INFO"/>
     <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping" level="DEBUG"/>
-    <logger name="org.springframework" level="INFO"/>
 </configuration>

--- a/backend/api-gateway/build.gradle
+++ b/backend/api-gateway/build.gradle
@@ -18,6 +18,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
+    implementation 'io.micrometer:context-propagation'
+
+
 }
 
 tasks.named('test') {

--- a/backend/api-gateway/src/main/java/com/rusobr/gateway/infrastructure/filter/LoggingFilter.java
+++ b/backend/api-gateway/src/main/java/com/rusobr/gateway/infrastructure/filter/LoggingFilter.java
@@ -1,0 +1,71 @@
+package com.rusobr.gateway.infrastructure.filter;
+
+import net.logstash.logback.argument.StructuredArguments;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+public class LoggingFilter implements GlobalFilter, Ordered {
+
+    private static final Logger log = LoggerFactory.getLogger(LoggingFilter.class);
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+
+        long start = System.currentTimeMillis();
+
+        ServerHttpRequest request = exchange.getRequest();
+
+        return exchange.getPrincipal()
+                .cast(Authentication.class)
+                .map(Authentication::getPrincipal)
+                .cast(Jwt.class)
+                .map(jwt -> jwt.getClaimAsString("user_id"))
+                .defaultIfEmpty("anonymous")
+                .flatMap(userId -> {
+
+                    log.info(
+                            "Incoming request",
+                            StructuredArguments.keyValue("userId", userId),
+                            StructuredArguments.keyValue("method", request.getMethod().name()),
+                            StructuredArguments.keyValue("path", request.getPath().value()),
+                            StructuredArguments.keyValue("query", request.getURI().getQuery()),
+                            StructuredArguments.keyValue("remoteIp",
+                                    request.getRemoteAddress() != null
+                                            ? request.getRemoteAddress().getAddress().getHostAddress()
+                                            : null)
+                    );
+
+                    return chain.filter(exchange)
+                            .doFinally(signal -> {
+
+                                log.info(
+                                        "Outgoing response",
+                                        StructuredArguments.keyValue("userId", userId),
+                                        StructuredArguments.keyValue("method", request.getMethod().name()),
+                                        StructuredArguments.keyValue("path", request.getPath().value()),
+                                        StructuredArguments.keyValue("status",
+                                                exchange.getResponse().getStatusCode() != null
+                                                        ? exchange.getResponse().getStatusCode().value()
+                                                        : 0),
+                                        StructuredArguments.keyValue("durationMs",
+                                                System.currentTimeMillis() - start)
+                                );
+                            });
+                });
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+}

--- a/backend/api-gateway/src/main/java/com/rusobr/gateway/infrastructure/security/SecurityConfig.java
+++ b/backend/api-gateway/src/main/java/com/rusobr/gateway/infrastructure/security/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 .authorizeExchange(exchange -> exchange
                         .pathMatchers("/user-service/v3/api-docs/**", "/swagger-ui/**").permitAll()
                         .pathMatchers("/academic-service/v3/api-docs/**", "/swagger-ui/**").permitAll()
-                        .pathMatchers("/actuator/health").permitAll()
+                        .pathMatchers("/actuator/**").permitAll()
                         .anyExchange().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> {}))
                 .build();

--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -2,6 +2,8 @@ server:
   port: 8080
 
 spring:
+  reactor:
+    context-propagation: auto
   application:
     name: api-gateway
 
@@ -52,6 +54,25 @@ eureka:
       defaultZone: ${EUREKA_URL:http://user:password@localhost:8761/eureka/}
 
 logging:
-  level:
-    io.netty.resolver.dns: DEBUG
-    reactor.netty.http.client: DEBUG
+  file:
+    path: ${LOGS_PATH:./logs}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, metrics, prometheus
+  endpoint:
+    health:
+      show-details: never
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+        http.client.requests: true
+  tag:
+    application: ${spring.application.name}
+  tracing:
+    enabled: true
+    sampling:
+      probability: 1.0

--- a/backend/api-gateway/src/main/resources/logback-spring.xml
+++ b/backend/api-gateway/src/main/resources/logback-spring.xml
@@ -1,33 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <!-- считываем spring.application.name -->
-    <springProperty name="SERVICE_NAME" source="spring.application.name" />
-
-    <!-- если переменная не задана - используется logs -->
-    <property name="LOG_PATH" value="${LOG_PATH:-logs}" />
+    <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="api-gateway"/>
+    <springProperty scope="context" name="logPath" source="logging.file.path" defaultValue="/app/logs"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [traceId=%X{traceId} spanId=%X{spanId}] - %msg%n</pattern>
         </encoder>
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_PATH}/${SERVICE_NAME}.log</file>
-
+        <file>${logPath}/${appName}.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/${SERVICE_NAME}.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${logPath}/${appName}-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>100MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
             <maxHistory>7</maxHistory>
+            <totalSizeCap>2GB</totalSizeCap>
         </rollingPolicy>
-
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} traceId=%X{traceId} - %msg%n</pattern>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"app":"${appName}"}</customFields>
+            <includeContext>false</includeContext>
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>spanId</includeMdcKeyName>
         </encoder>
+    </appender>
+
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FILE"/>
+        <queueSize>1000</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <includeCallerData>false</includeCallerData>
     </appender>
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE"/>
+        <appender-ref ref="ASYNC_FILE"/>
     </root>
+
+    <logger name="org.springframework" level="INFO"/>
+    <logger name="com.netflix.discovery" level="WARN"/>
+    <logger name="com.netflix.eureka" level="WARN"/>
+    <logger name="reactor.netty.http.client" level="INFO"/>
+
+<!--    <springProfile name="debug-gateway">-->
+<!--        <logger name="org.springframework.cloud.gateway" level="DEBUG"/>-->
+<!--    </springProfile>-->
 
 </configuration>

--- a/backend/common/src/main/resources/logback-include.xml
+++ b/backend/common/src/main/resources/logback-include.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [traceId=%X{traceId}] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${logPath}/${appName}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${logPath}/${appName}-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>100MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"app":"${appName}"}</customFields>
+            <includeContext>false</includeContext>
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>userId</includeMdcKeyName>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FILE"/>
+        <queueSize>1000</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <includeCallerData>false</includeCallerData>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="ASYNC_FILE"/>
+    </root>
+
+    <logger name="org.springframework.web.client.RestTemplate" level="INFO"/>
+    <logger name="com.netflix.discovery" level="WARN"/>
+    <logger name="com.netflix.eureka" level="WARN"/>
+    <logger name="org.springframework.web" level="INFO"/>
+    <logger name="org.springframework" level="INFO"/>
+
+</included>

--- a/backend/eureka-server/build.gradle
+++ b/backend/eureka-server/build.gradle
@@ -12,6 +12,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 bootJar {

--- a/backend/eureka-server/src/main/resources/application.yml
+++ b/backend/eureka-server/src/main/resources/application.yml
@@ -16,3 +16,19 @@ eureka:
   client:
     register-with-eureka: false
     fetch-registry: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, metrics, prometheus
+  endpoint:
+    health:
+      show-details: never
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+        http.client.requests: true
+  tag:
+    application: ${spring.application.name}

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.github.openfeign:feign-micrometer'
+    implementation 'io.micrometer:context-propagation'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }

--- a/backend/user-service/src/main/java/com/rusobr/user/config/SecurityConfig.java
+++ b/backend/user-service/src/main/java/com/rusobr/user/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .cors(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(req -> {
                     req
-                            .requestMatchers("/public/**", "/actuator/health").permitAll()
+                            .requestMatchers("/public/**", "/actuator/**").permitAll()
                             .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 
                             .requestMatchers(POST, "/api/v1/students/batch").hasAnyRole(TEACHER.name(), ADMIN.name())

--- a/backend/user-service/src/main/resources/application.yml
+++ b/backend/user-service/src/main/resources/application.yml
@@ -49,6 +49,8 @@ eureka:
       defaultZone: ${EUREKA_URL:http://user:password@localhost:8761/eureka/}
 
 logging:
+  file:
+    path: ${LOGS_PATH:./logs}
   loki:
     url: ${LOKI_URL:http://localhost:3100}/loki/api/v1/push
   level:
@@ -83,13 +85,23 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,circuitbreakers,circuitbreakerevents,metrics
+        include: health, circuitbreakers, circuitbreakerevents, metrics, prometheus
+  endpoint:
+    health:
+      show-details: never
   health:
     circuitbreakers:
       enabled: true
   tracing:
     sampling:
       probability: 1.0
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+        http.client.requests: true
+  tag:
+    application: ${spring.application.name}
 
 keycloak:
   url: ${KC_URL:http://localhost:9090}

--- a/backend/user-service/src/main/resources/logback-spring.xml
+++ b/backend/user-service/src/main/resources/logback-spring.xml
@@ -1,48 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="user-service"/>
+    <springProperty scope="context" name="logPath" source="logging.file.path" defaultValue="/app/logs"/>
 
-    <!-- Console Appender -->
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
+    <include resource="logback-include.xml"/>
 
-    <!-- File Appender для Alloy -->
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/app/logs/${appName}.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/app/logs/${appName}-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>100MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <maxHistory>7</maxHistory>
-        </rollingPolicy>
-
-        <!-- JSON формат для легкого парсинга -->
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <customFields>{"app":"${appName}"}</customFields>
-        </encoder>
-    </appender>
-
-    <!-- Async wrapper для FILE -->
-    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="FILE"/>
-        <queueSize>1000</queueSize>
-        <discardingThreshold>0</discardingThreshold>
-    </appender>
-
-    <root level="INFO">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="ASYNC_FILE"/>
-    </root>
-
-    <!-- Настройка уровней -->
-    <logger name="org.springframework.web.client.RestTemplate" level="INFO"/>
-    <logger name="com.netflix.discovery" level="WARN"/>
-    <logger name="com.netflix.eureka" level="WARN"/>
-    <logger name="org.springframework.web" level="INFO"/>
     <logger name="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping" level="DEBUG"/>
-    <logger name="org.springframework" level="INFO"/>
 </configuration>

--- a/configs/alloy-config.alloy
+++ b/configs/alloy-config.alloy
@@ -1,35 +1,54 @@
-local.file_match "spring_logs" {
-  path_targets = [{
-    __path__ = "/logs/*.log",
-  }]
+livedebugging {
+  enabled = true
 }
 
-loki.source.file "spring_apps" {
-  targets    = local.file_match.spring_logs.targets
-  forward_to = [loki.process.spring_parser.receiver]
+local.file_match "log_files" {
+  path_targets = [
+    {"__path__" = "/app/logs/*/*.log"},
+  ]
 }
 
-loki.process "spring_parser" {
-  forward_to = [loki.write.local_loki.receiver]
+loki.source.file "app_logs" {
+  targets    = local.file_match.log_files.targets
+  forward_to = [loki.process.parse.receiver]
+}
 
-  stage.json {
+loki.process "parse" {
+stage.json {
     expressions = {
-      level   = "level",
-      logger  = "logger",
-      message = "message",
-      trace   = "trace_id",
+      level     = "level",
+      app       = "app",
+      traceId   = "traceId",
+      spanId    = "spanId",
+      userId    = "userId",
+      timestamp = "\"@timestamp\"",
     }
-  }
+}
 
   stage.labels {
     values = {
-      level  = "",
-      logger = "",
+      level = "",
+      app   = "",
     }
   }
+
+  stage.structured_metadata {
+    values = {
+      traceId = "",
+      spanId  = "",
+      userId  = "",
+    }
+  }
+
+  stage.timestamp {
+    source = "timestamp"
+    format = "RFC3339"
+  }
+
+  forward_to = [loki.write.default.receiver]
 }
 
-loki.write "local_loki" {
+loki.write "default" {
   endpoint {
     url = "http://loki:3100/loki/api/v1/push"
   }

--- a/configs/dashboards/prometheus-stats.json
+++ b/configs/dashboards/prometheus-stats.json
@@ -1,0 +1,111 @@
+{
+  "title": "dnevnik stats",
+  "uid": "sb-adv-metrics-02",
+  "tags": ["spring-boot", "database", "cpu"],
+  "timezone": "browser",
+  "schemaVersion": 36,
+  "refresh": "10s",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "default", "value": "default" }
+      },
+      {
+        "name": "application",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(application)",
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "HTTP Errors Rate (4xx / 5xx)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{application=~\"$application\", status=~\"5..\"}[1m])) by (application, status)",
+          "legendFormat": "{{application}} - {{status}} (Server Error)"
+        },
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{application=~\"$application\", status=~\"4..\"}[1m])) by (application, status)",
+          "legendFormat": "{{application}} - {{status}} (Client Error)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "bars", "lineWidth": 1, "fillOpacity": 80 },
+          "color": { "mode": "palette-classic" },
+          "unit": "reqps"
+        }
+      }
+    },
+    {
+      "title": "CPU Usage (%)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "process_cpu_usage{application=~\"$application\"} * 100",
+          "legendFormat": "{{application}} - JVM CPU"
+        },
+        {
+          "expr": "system_cpu_usage{application=~\"$application\"} * 100",
+          "legendFormat": "{{application}} - System CPU"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "percent", "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2 } }
+      }
+    },
+    {
+      "title": "Database Connection Pool (HikariCP)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "hikaricp_connections_active{application=~\"$application\"}",
+          "legendFormat": "{{application}} - Active"
+        },
+        {
+          "expr": "hikaricp_connections_idle{application=~\"$application\"}",
+          "legendFormat": "{{application}} - Idle"
+        },
+        {
+          "expr": "hikaricp_connections_max{application=~\"$application\"}",
+          "legendFormat": "{{application}} - Max Limit"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 } }
+      }
+    },
+    {
+      "title": "Garbage Collection (GC) Pause Duration",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "rate(jvm_gc_pause_seconds_sum{application=~\"$application\"}[1m])",
+          "legendFormat": "{{application}} - GC Pause Time"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 1 } }
+      }
+    }
+  ]
+}

--- a/configs/dashboards/trace-lookup.json
+++ b/configs/dashboards/trace-lookup.json
@@ -1,0 +1,38 @@
+{
+  "title": "Trace lookup",
+  "templating": {
+    "list": [
+      {
+        "name": "traceId",
+        "type": "textbox",
+        "label": "Trace ID",
+        "query": "",
+        "current": { "text": "", "value": "" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "logs",
+      "title": "Поиск по traceId всех сервисов",
+      "gridPos": { "h": 28, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "{app=~\"api-gateway|user-service|academic-service\"} | traceId=\"$traceId\"",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showLabels": true,
+        "showTime": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Ascending"
+      }
+    }
+  ]
+}

--- a/configs/grafana-dashboards.yaml
+++ b/configs/grafana-dashboards.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: default
+    folder: dnevnik
+    type: file
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    disableDeletion: false
+    options:
+      path: /etc/grafana/provisioning/dashboards/json

--- a/configs/grafana-datasources.yaml
+++ b/configs/grafana-datasources.yaml
@@ -2,9 +2,30 @@ apiVersion: 1
 
 datasources:
   - name: Loki
+    uid: loki
     type: loki
     access: proxy
     url: http://loki:3100
     isDefault: true
     jsonData:
       maxLines: 1000
+      derivedFields:
+        - datasourceUid: loki
+          matcherRegex: '"traceId":"(\w+)"'
+          name: traceId
+          url: '{app=~"api-gateway|user-service|academic-service"} | traceId="$${__value.raw}"'
+          urlDisplayLabel: "Показать весь запрос"
+
+providers:
+  - name: default
+    folder: dnevnik
+    type: file
+    options:
+      path: /etc/grafana/provisioning/dashboards/json
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    jsonData:
+      timeInterval: 15s

--- a/configs/loki-config.yaml
+++ b/configs/loki-config.yaml
@@ -18,19 +18,20 @@ common:
 
 schema_config:
   configs:
-    - from: 2020-10-24
-      store: boltdb-shipper
+    - from: 2024-01-01
+      store: tsdb
       object_store: filesystem
-      schema: v11
+      schema: v13
       index:
         prefix: index_
         period: 24h
-
-ruler:
-  alertmanager_url: http://localhost:9093
 
 limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   ingestion_rate_mb: 16
   ingestion_burst_size_mb: 32
+  allow_structured_metadata: true
+
+ruler:
+  alertmanager_url: http://localhost:9093

--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -1,0 +1,26 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'api-gateway'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['api-gateway:8080']
+
+  - job_name: 'user-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['user-service:9001']
+
+  - job_name: 'academic-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['academic-service:9002']
+
+  - job_name: 'eureka-server'
+    metrics_path: '/actuator/prometheus'
+    basic_auth:
+      username: 'user'
+      password: 'password'
+    static_configs:
+      - targets: ['eureka-server:8761']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,8 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
       - ./configs/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - ./configs/grafana-dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml
+      - ./configs/dashboards:/etc/grafana/provisioning/dashboards/json
     depends_on:
       - loki
     networks:
@@ -81,12 +83,27 @@ services:
       - "4318:4318"  # OTLP HTTP
     volumes:
       - ./configs/alloy-config.alloy:/etc/alloy/config.alloy
-      - ./logs:/logs
+      - ./logs:/app/logs
+      - alloy-data:/var/lib/alloy/data
     command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     networks:
       - micro-net
     depends_on:
       - loki
+  
+  prometheus:
+    image: prom/prometheus:v2.53.0
+    container_name: prometheus
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./configs/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.retention.time=15d'
+    networks:
+      - micro-net
 
   eureka-server:
     build:
@@ -96,7 +113,7 @@ services:
         SERVICE_NAME: eureka-server
     container_name: eureka-server
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8761/actuator/health"]
+      test: ["CMD", "curl", "-f", "http://user:password@localhost:8761/actuator/health"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -126,9 +143,10 @@ services:
       - KC_URL=http://keycloak:8080
       - KC_PUBLIC_URL=http://localhost:9090
       - KC_REALM=dnevnik-realm
-      - EUREKA_URL=http://user:password@eureka-server:8761
+      - EUREKA_URL=http://user:password@eureka-server:8761/eureka/
       - FRONTEND_URL=http://localhost:5173
       - APP_NAME=api-gateway
+      - LOGS_PATH=/app/logs
     volumes:
       - ./logs/api-gateway:/app/logs
     networks:
@@ -158,8 +176,9 @@ services:
       - PSQL_USER_USERNAME=school_user
       - PSQL_USER_PASSWORD=school_pass
       - LOKI_URL=http://loki:3100
-      - EUREKA_URL=http://user:password@eureka-server:8761
+      - EUREKA_URL=http://user:password@eureka-server:8761/eureka/
       - APP_NAME=user-service
+      - LOGS_PATH=/app/logs
     volumes:
       - ./logs/user-service:/app/logs
     networks:
@@ -189,8 +208,9 @@ services:
       - PSQL_ACADEMIC_USERNAME=school_user
       - PSQL_ACADEMIC_PASSWORD=school_pass
       - LOKI_URL=http://loki:3100
-      - EUREKA_URL=http://user:password@eureka-server:8761
+      - EUREKA_URL=http://user:password@eureka-server:8761/eureka/
       - APP_NAME=academic-service
+      - LOGS_PATH=/app/logs
     volumes:
       - ./logs/academic-service:/app/logs
     networks:
@@ -212,6 +232,8 @@ volumes:
   keycloak_data:
   loki-data:
   grafana-data:
+  alloy-data:
+  prometheus-data:
 
 networks:
   micro-net:


### PR DESCRIPTION
- Добавлен сквозной traceId в фильтрах API Gateway (incoming/outcoming)
- Настроена трассировка запросов в Grafana (панель Trace lookup)
- Унифицирован logback.xml для микросервисов
- Настроен Prometheus, создана базовая панель "dnevnik stats" в Grafana
- Включен allow_structured_metadata и обновлена схема в Loki
- Открыт доступ к /actuator/** (permitAll) для сбора метрик
- Исправлена race condition при сборке Gradle cacheMount в Docker

Closes #136