### PR TITLE
feat(backend): IDOR-защита мутаций учителя, логирование, инвалидация кэшей, фиксы PDF/security, тесты

### DIFF
--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AcademicPeriodService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AcademicPeriodService.java
@@ -72,6 +72,7 @@ public class AcademicPeriodService {
         validateAcademicYear(academicPeriod.getAcademicYear());
 
         academicPeriod.open();
+        log.info("Academic period opened: id={}, academicYearId={}", id, academicPeriod.getAcademicYear().getId());
     }
 
     @CacheEvict(value = "academicPeriods", allEntries = true)
@@ -82,6 +83,7 @@ public class AcademicPeriodService {
         validateAcademicYear(academicPeriod.getAcademicYear());
 
         academicPeriod.close();
+        log.info("Academic period closed: id={}, academicYearId={}", id, academicPeriod.getAcademicYear().getId());
     }
 
     @CacheEvict(value = "academicPeriods", allEntries = true)
@@ -95,7 +97,9 @@ public class AcademicPeriodService {
         AcademicPeriod period = academicPeriodMapper.toEntity(request);
         period.setAcademicYear(academicYear);
 
-        return academicPeriodMapper.toResponse(academicPeriodRepository.save(period));
+        AcademicPeriodResponse response = academicPeriodMapper.toResponse(academicPeriodRepository.save(period));
+        log.info("Academic period created: request={}", request);
+        return response;
     }
 
     @CacheEvict(value = "academicPeriods", allEntries = true)
@@ -115,6 +119,7 @@ public class AcademicPeriodService {
         }
 
         if (request.name() != null) academicPeriod.setName(request.name());
+        log.info("Academic period updated: id={} request={}", id, request);
     }
 
     @CacheEvict(value = "academicPeriods", allEntries = true)
@@ -125,6 +130,7 @@ public class AcademicPeriodService {
         validateAcademicYear(academicPeriod.getAcademicYear());
 
         academicPeriodRepository.delete(academicPeriod);
+        log.info("Academic period deleted: id={}", id);
     }
 
     // helpers

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AcademicYearService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AcademicYearService.java
@@ -9,6 +9,7 @@ import com.rusobr.academic.infrastructure.persistence.repository.AcademicYearRep
 import com.rusobr.academic.web.dto.academicYear.AcademicYearRequest;
 import com.rusobr.academic.web.dto.academicYear.AcademicYearResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AcademicYearService {
 
     private final AcademicYearRepository academicYearRepository;
@@ -42,7 +44,9 @@ public class AcademicYearService {
     public AcademicYearResponse create(AcademicYearRequest request) {
         validateDates(request.startDate(), request.endDate());
         AcademicYear academicYear = academicYearMapper.toEntity(request);
-        return academicYearMapper.toResponse(academicYearRepository.save(academicYear));
+        AcademicYearResponse response = academicYearMapper.toResponse(academicYearRepository.save(academicYear));
+        log.info("Academic year created: request={}", request);
+        return response;
     }
 
     @CacheEvict(value = "academicYears", allEntries = true)
@@ -53,6 +57,7 @@ public class AcademicYearService {
         validateDates(academicYear.getStartDate(), academicYear.getEndDate());
 
         academicYear.open();
+        log.info("Academic year opened: id={}", id);
     }
 
     @CacheEvict(value = "academicYears", allEntries = true)
@@ -63,6 +68,7 @@ public class AcademicYearService {
         validateDates(academicYear.getStartDate(), academicYear.getEndDate());
 
         academicYear.close();
+        log.info("Academic year closed: id={}", id);
     }
 
     @CacheEvict(value = "academicYears", allEntries = true)
@@ -84,7 +90,9 @@ public class AcademicYearService {
             academicYear.setEndDate(request.endDate());
         }
 
-        return academicYearMapper.toResponse(academicYear);
+        AcademicYearResponse response = academicYearMapper.toResponse(academicYear);
+        log.info("Academic year updated: id={}, request={}", id, request);
+        return response;
     }
 
     @CacheEvict(value = "academicYears", allEntries = true)
@@ -92,6 +100,7 @@ public class AcademicYearService {
     public void delete(Long id) {
         AcademicYear academicYear = findOrThrow(id);
         academicYearRepository.delete(academicYear);
+        log.info("Academic year deleted: id={}", id);
     }
 
     // helpers

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AttendanceService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AttendanceService.java
@@ -25,7 +25,7 @@ public class AttendanceService {
     private final LessonInstanceService lessonInstanceService;
     private final AcademicPeriodService academicPeriodService;
 
-    @CacheEvict(value = {"journalByAssignment", "journalByStudentId"}, allEntries = true)
+    @CacheEvict(value = {"journalByAssignment", "journalByStudentId", "schedulesByStudentId"}, allEntries = true)
     @Transactional
     public AttendanceResponse create(AttendanceRequest attendanceRequest) {
         LessonInstance lessonInstance = lessonInstanceService.getById(attendanceRequest.lessonInstanceId());
@@ -50,7 +50,7 @@ public class AttendanceService {
         return response;
     }
 
-    @CacheEvict(value = {"journalByAssignment", "journalByStudentId"}, allEntries = true)
+    @CacheEvict(value = {"journalByAssignment", "journalByStudentId", "schedulesByStudentId"}, allEntries = true)
     @Transactional
     public void delete(Long id) {
         attendanceRepository.deleteById(id);

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AttendanceService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AttendanceService.java
@@ -9,6 +9,7 @@ import com.rusobr.academic.web.dto.attendances.AttendanceRequest;
 import com.rusobr.academic.web.dto.attendances.AttendanceResponse;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.ConflictException;
+import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -53,6 +54,15 @@ public class AttendanceService {
     @CacheEvict(value = {"journalByAssignment", "journalByStudentId", "schedulesByStudentId"}, allEntries = true)
     @Transactional
     public void delete(Long id) {
+
+        Attendance attendance = attendanceRepository.findWithLessonInstanceById(id)
+                .orElseThrow(() -> new NotFoundException("Attendance with id: %d".formatted(id), AcademicExceptionCode.ATTENDANCE_NOT_FOUND));
+
+        AcademicPeriod academicPeriod = academicPeriodService.getByDate(attendance.getLessonInstance().getLessonDate());
+        if (academicPeriod.isClosed()) {
+            throw new ConflictException("Academic period is closed", AcademicExceptionCode.ACADEMIC_PERIOD_CLOSED_CONFLICT);
+        }
+
         attendanceRepository.deleteById(id);
         log.info("Attendance deleted: id={}", id);
     }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AttendanceService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/AttendanceService.java
@@ -10,12 +10,14 @@ import com.rusobr.academic.web.dto.attendances.AttendanceResponse;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.ConflictException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AttendanceService {
 
     private final AttendanceRepository attendanceRepository;
@@ -43,13 +45,16 @@ public class AttendanceService {
                 .orElseGet(() -> attendanceMapper.toAttendance(attendanceRequest, lessonInstance)
                 );
 
-        return attendanceMapper.toAttendanceResponse(attendanceRepository.save(attendance));
+        AttendanceResponse response = attendanceMapper.toAttendanceResponse(attendanceRepository.save(attendance));
+        log.info("Attendance created: request={}", attendanceRequest);
+        return response;
     }
 
     @CacheEvict(value = {"journalByAssignment", "journalByStudentId"}, allEntries = true)
     @Transactional
     public void delete(Long id) {
         attendanceRepository.deleteById(id);
+        log.info("Attendance deleted: id={}", id);
     }
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/ClassStudentService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/ClassStudentService.java
@@ -10,6 +10,7 @@ import com.rusobr.common.dto.UserFeignResponse;
 import com.rusobr.common.exception.ConflictException;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -19,6 +20,7 @@ import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ClassStudentService {
 
     private final SchoolClassRepository schoolClassRepository;
@@ -49,6 +51,7 @@ public class ClassStudentService {
                     .build());
             return null;
         });
+        log.info("Add student to class: classId={}, studentId={}", classId, studentId);
     }
 
     @Transactional
@@ -58,6 +61,7 @@ public class ClassStudentService {
                         .formatted(classId, studentId), AcademicExceptionCode.CLASS_STUDENT_NOT_FOUND));
 
         classStudentRepository.delete(classStudent);
+        log.info("Remove student from class: classId={}, studentId={}", classId, studentId);
     }
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/FinalGradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/FinalGradeService.java
@@ -109,7 +109,10 @@ public class FinalGradeService {
         FinalGrade finalGrade = finalGradeMapper.toFinalGrade(finalGradeRequest);
         finalGrade.setTeachingAssignment(teachingAssignment);
         finalGrade.setAcademicYear(academicYear);
-        return finalGradeMapper.toFinalGradeCreateResponse(finalGradeRepository.save(finalGrade));
+        FinalGradeCreateResponse response = finalGradeMapper
+                .toFinalGradeCreateResponse(finalGradeRepository.save(finalGrade));
+        log.info("Create final grade: request={}", finalGradeRequest);
+        return response;
     }
 
     @CacheEvict(value = {"finalGradesByStudent", "finalGradesByAssignment"}, allEntries = true)
@@ -132,6 +135,7 @@ public class FinalGradeService {
         });
 
         finalGradeRepository.deleteById(id);
+        log.info("Delete final grade: gradeId={}", id);
     }
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/FinalGradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/FinalGradeService.java
@@ -85,7 +85,7 @@ public class FinalGradeService {
         return new DbData(finalGrades, studentIds);
     }
 
-    @CacheEvict(value = {"finalGradesByStudent", "finalGradesByAssignment"}, allEntries = true)
+    @CacheEvict(value = {"finalGradesByStudent", "finalGradesByAssignment", "journalPeriodFinalGradeByStudentId"}, allEntries = true)
     @Transactional
     public FinalGradeCreateResponse create(FinalGradeRequest finalGradeRequest) {
 
@@ -115,7 +115,7 @@ public class FinalGradeService {
         return response;
     }
 
-    @CacheEvict(value = {"finalGradesByStudent", "finalGradesByAssignment"}, allEntries = true)
+    @CacheEvict(value = {"finalGradesByStudent", "finalGradesByAssignment", "journalPeriodFinalGradeByStudentId"}, allEntries = true)
     @Transactional
     public void delete(Long id) {
         FinalGrade finalGrade = finalGradeRepository.findWithAcademicYearById(id)

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/GradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/GradeService.java
@@ -20,6 +20,7 @@ import com.rusobr.common.exception.ConflictException;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,7 @@ import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class GradeService {
 
     private final GradeRepository gradeRepository;
@@ -83,9 +85,9 @@ public class GradeService {
 
     @CacheEvict(value = {"gradesByDate", "gradesByPeriod", "journalByAssignment", "journalByStudentId", "schedulesByStudentId"}, allEntries = true)
     @Transactional
-    public CreateGradeResponse create(CreateGradeRequest gradeDto) {
-        LessonInstance lessonInstance = lessonInstanceRepository.findById(gradeDto.lessonInstanceId())
-                .orElseThrow(() -> new NotFoundException("Lesson instance with id: %d".formatted(gradeDto.lessonInstanceId()),
+    public CreateGradeResponse create(CreateGradeRequest request) {
+        LessonInstance lessonInstance = lessonInstanceRepository.findById(request.lessonInstanceId())
+                .orElseThrow(() -> new NotFoundException("Lesson instance with id: %d".formatted(request.lessonInstanceId()),
                         AcademicExceptionCode.LESSON_INSTANCE_NOT_FOUND));
         AcademicPeriod academicPeriod = academicPeriodService.getByDate(lessonInstance.getLessonDate());
         if (academicPeriod.isClosed()) {
@@ -93,11 +95,13 @@ public class GradeService {
                     AcademicExceptionCode.ACADEMIC_PERIOD_CLOSED_CONFLICT);
         }
 
-        Grade grade = gradeMapper.toGrade(gradeDto);
+        Grade grade = gradeMapper.toGrade(request);
         grade.setLessonInstance(lessonInstance);
 
-        return gradeMapper.toCreateGradeResponseDto(
+        CreateGradeResponse response = gradeMapper.toCreateGradeResponseDto(
                 gradeRepository.save(grade), lessonInstanceMapper.toLessonInstanceDto(lessonInstance));
+        log.info("Create grade: request={}", request);
+        return response;
     }
 
     @CacheEvict(value = {"gradesByDate", "gradesByPeriod", "journalByAssignment", "journalByStudentId"}, allEntries = true)
@@ -112,6 +116,7 @@ public class GradeService {
         }
 
         gradeRepository.delete(grade);
+        log.info("Delete grade: id={}", id);
     }
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/GradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/GradeService.java
@@ -104,7 +104,7 @@ public class GradeService {
         return response;
     }
 
-    @CacheEvict(value = {"gradesByDate", "gradesByPeriod", "journalByAssignment", "journalByStudentId"}, allEntries = true)
+    @CacheEvict(value = {"gradesByDate", "gradesByPeriod", "journalByAssignment", "journalByStudentId", "schedulesByStudentId"}, allEntries = true)
     @Transactional
     public void delete(Long id) {
         Grade grade = gradeRepository.findWithLessonInstanceById(id)

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/HomeworkService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/HomeworkService.java
@@ -12,6 +12,7 @@ import com.rusobr.common.exception.ConflictException;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
@@ -24,6 +25,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class HomeworkService {
 
     private final HomeworkRepository homeworkRepository;
@@ -60,7 +62,9 @@ public class HomeworkService {
                 .text(homeworkRequest.text())
                 .build();
 
-        return homeworkMapper.toHomeworkResponse(homeworkRepository.save(homework));
+        HomeworkResponse response = homeworkMapper.toHomeworkResponse(homeworkRepository.save(homework));
+        log.info("Create homework: request={}", homeworkRequest);
+        return response;
     }
 
     @CacheEvict(value = {"homeworksByDate", "homeworksByAssignment"}, allEntries = true)
@@ -76,6 +80,7 @@ public class HomeworkService {
         }
 
         homeworkRepository.delete(homework);
+        log.info("Delete homework: id={}", id);
     }
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/HomeworkService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/HomeworkService.java
@@ -39,14 +39,13 @@ public class HomeworkService {
         return homeworkRepository.findHomeworksByDate(date, studentId).stream().map(homeworkMapper::toWithSubjectResponse).toList();
     }
 
-    @Cacheable(value = "homeworksByAssignment", key = "#teachingAssignmentId")
     @Transactional(readOnly = true)
     public Page<HomeworkResponse> getByAssignment(Long teachingAssignmentId, Pageable pageable) {
         Page<Homework> homeworkPage = homeworkRepository.findHomeworksByTeachingAssignmentId(teachingAssignmentId, pageable);
         return homeworkPage.map(homeworkMapper::toHomeworkResponse);
     }
 
-    @CacheEvict(value = {"homeworksByDate", "homeworksByAssignment"}, allEntries = true)
+    @CacheEvict(value = {"homeworksByDate", "homeworksByAssignment", "schedulesByStudentId"}, allEntries = true)
     @Transactional
     public HomeworkResponse create(HomeworkRequest homeworkRequest) {
         LessonInstance lessonInstance = lessonInstanceService.getById(homeworkRequest.lessonInstanceId());
@@ -67,7 +66,7 @@ public class HomeworkService {
         return response;
     }
 
-    @CacheEvict(value = {"homeworksByDate", "homeworksByAssignment"}, allEntries = true)
+    @CacheEvict(value = {"homeworksByDate", "homeworksByAssignment", "schedulesByStudentId"}, allEntries = true)
     @Transactional
     public void delete(Long id) {
         Homework homework = homeworkRepository.findWithLessonInstanceById(id)

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/JournalService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/JournalService.java
@@ -19,6 +19,7 @@ import com.rusobr.academic.web.dto.lessonInstance.teacher.TeacherJournalResponse
 import com.rusobr.common.dto.BatchUserResponse;
 import com.rusobr.common.dto.UserFeignResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +38,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class JournalService {
 
     private final LessonInstanceRepository lessonInstanceRepository;
@@ -206,6 +208,7 @@ public class JournalService {
         }
 
         generateInstanceBetween(scheduleLesson, from, to);
+        log.info("Generate lesson instance for schedule: id={}, from={}, to={}", scheduleLesson.getId(), from, to);
     }
 
     public void generateInstanceBetween(ScheduleLesson scheduleLesson, LocalDate from, LocalDate to) {
@@ -227,6 +230,7 @@ public class JournalService {
             }
             current = current.plusWeeks(1);
         }
+        log.info("Generate lesson instance for schedule between: id={}, from={}, to={}", scheduleLesson.getId(), from, to);
     }
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/PeriodGradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/PeriodGradeService.java
@@ -16,6 +16,7 @@ import com.rusobr.common.dto.BatchUserResponse;
 import com.rusobr.common.exception.ConflictException;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PeriodGradeService {
 
     private final PeriodGradeRepository periodGradeRepository;
@@ -68,7 +70,6 @@ public class PeriodGradeService {
                 )
         );
     }
-
 
     @Cacheable(value = "periodGradesByAssignment", key = "#teachingAssignmentId + '#' + #currentAcademicPeriodId + '#' + #academicYearId")
     public PeriodGradeTeacherResponse getByAssignmentWithAverage(Long teachingAssignmentId, Long currentAcademicPeriodId, Long academicYearId) {
@@ -115,7 +116,8 @@ public class PeriodGradeService {
         }
 
         TeachingAssignment teachingAssignment = teachingAssignmentRepository.findById(dto.teachingAssignmentId())
-                .orElseThrow(() -> new NotFoundException("Teaching assignment with id: %d not found".formatted(dto.teachingAssignmentId()),
+                .orElseThrow(() -> new NotFoundException("Teaching assignment with id: %d not found"
+                        .formatted(dto.teachingAssignmentId()),
                         AcademicExceptionCode.TEACHING_ASSIGNMENT_NOT_FOUND));
 
         PeriodGrade periodGrade = PeriodGrade.builder()
@@ -126,8 +128,9 @@ public class PeriodGradeService {
                 .teachingAssignment(teachingAssignment)
                 .build();
 
-        return periodGradeMapper.toPeriodGradeResponse(periodGradeRepository.save(periodGrade));
-
+        PeriodGradeResponse response = periodGradeMapper.toPeriodGradeResponse(periodGradeRepository.save(periodGrade));
+        log.info("Create period grade: request={}", dto);
+        return response;
     }
 
     @CacheEvict(value = {"periodGradesByAssignment", "periodGradesByStudentId"}, allEntries = true)
@@ -143,6 +146,7 @@ public class PeriodGradeService {
         }
 
         periodGradeRepository.delete(periodGrade);
+        log.info("Delete period grade: id={}", periodGradeId);
     }
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/PeriodGradeService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/PeriodGradeService.java
@@ -106,7 +106,7 @@ public class PeriodGradeService {
         return new PeriodGradeDbData(studentIds, periodGradesMap, averageGradesMap);
     }
 
-    @CacheEvict(value = {"periodGradesByAssignment", "periodGradesByStudentId"}, allEntries = true)
+    @CacheEvict(value = {"periodGradesByAssignment", "periodGradesByStudentId", "journalPeriodFinalGradeByStudentId"}, allEntries = true)
     @Transactional
     public PeriodGradeResponse create(PeriodGradeRequest dto) {
         AcademicPeriod academicPeriod = academicPeriodService.getById(dto.academicPeriodId());
@@ -133,7 +133,7 @@ public class PeriodGradeService {
         return response;
     }
 
-    @CacheEvict(value = {"periodGradesByAssignment", "periodGradesByStudentId"}, allEntries = true)
+    @CacheEvict(value = {"periodGradesByAssignment", "periodGradesByStudentId", "journalPeriodFinalGradeByStudentId"}, allEntries = true)
     @Transactional
     public void delete(Long periodGradeId) {
         PeriodGrade periodGrade = periodGradeRepository.findWithAcademicPeriodById(periodGradeId)

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/ScheduleService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/ScheduleService.java
@@ -16,6 +16,7 @@ import com.rusobr.common.exception.ConflictException;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -30,6 +31,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ScheduleService {
 
     private final ScheduleLessonRepository scheduleLessonRepository;
@@ -164,6 +166,7 @@ public class ScheduleService {
     public void create(ScheduleLessonRequest scheduleLessonRequest) {
         userClient.getTeacherById(scheduleLessonRequest.teacherId());
         self.createTransactional(scheduleLessonRequest);
+        log.info("Create schedule request={}", scheduleLessonRequest);
     }
 
     @Transactional
@@ -218,6 +221,7 @@ public class ScheduleService {
 
         // Удаляем lessonInstance к которым ничего не привязано
         lessonInstanceRepository.softDeleteFutureEmptyAfterDate(scheduleId, closeDate);
+        log.info("Schedule closed: scheduleId={}, closeDate={}", scheduleId, closeDate);
     }
 
     @Transactional
@@ -231,9 +235,7 @@ public class ScheduleService {
         for (ScheduleLesson sl : scheduleLessons) {
             lessonInstanceService.generateInstanceBetween(sl, fromDate, toDate);
         }
-
+        log.info("load schedule: classId={}, fromDate={}, toDate={}", classId, fromDate, toDate);
     }
-
-    //todo расписание для учителя какие уроки у нее
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/SchoolClassService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/SchoolClassService.java
@@ -123,12 +123,15 @@ public class SchoolClassService {
 
         SchoolClass schoolClass = schoolClassMapper.toSchoolClass(schoolClassReq, academicYear);
 
-        return schoolClassMapper.toSchoolClassResponse(schoolClassRepository.save(schoolClass));
+        SchoolClassResponse response = schoolClassMapper.toSchoolClassResponse(schoolClassRepository.save(schoolClass));
+        log.info("School class created: request={}", schoolClassReq);
+        return response;
     }
 
     public void assignTeacher(Long classId, Long teacherId) {
         userClient.getTeacherById(teacherId);
         self.assignTeacherDb(classId, teacherId);
+        log.info("School class assign teacher: classId={}, teacherId={}", classId, teacherId);
     }
 
     @Transactional
@@ -147,6 +150,7 @@ public class SchoolClassService {
         validateAcademicYearIsActive(schoolClass.getAcademicYear());
 
         schoolClass.setName(request.name());
+        log.info("School class updated: request={}", request);
     }
 
     @Transactional
@@ -156,6 +160,7 @@ public class SchoolClassService {
         validateAcademicYearIsActive(schoolClass.getAcademicYear());
 
         schoolClassRepository.delete(schoolClass);
+        log.info("School class deleted: id={}", id);
     }
 
     // helpers

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/SubjectService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/SubjectService.java
@@ -8,6 +8,7 @@ import com.rusobr.academic.infrastructure.persistence.repository.SubjectReposito
 import com.rusobr.academic.web.dto.subject.SubjectRequest;
 import com.rusobr.academic.web.dto.subject.SubjectResponseDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SubjectService {
 
     private final SubjectRepository subjectRepository;
@@ -35,7 +37,9 @@ public class SubjectService {
     @Transactional
     public SubjectResponseDto create(SubjectRequest dto) {
         Subject subject = subjectMapper.toSubject(dto);
-        return subjectMapper.toSubjectResponseDto(subjectRepository.save(subject));
+        SubjectResponseDto response = subjectMapper.toSubjectResponseDto(subjectRepository.save(subject));
+        log.info("Subject created: request={}", dto);
+        return response;
     }
 
     @Transactional
@@ -45,6 +49,7 @@ public class SubjectService {
                     AcademicExceptionCode.SUBJECT_NOT_FOUND);
         }
         subjectRepository.deleteById(id);
+        log.info("Subject deleted: id={}", id);
     }
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/TeacherSubjectService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/TeacherSubjectService.java
@@ -14,6 +14,7 @@ import com.rusobr.common.exception.ConflictException;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -28,6 +29,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TeacherSubjectService {
 
     private final TeacherSubjectRepository teacherSubjectRepository;
@@ -66,7 +68,9 @@ public class TeacherSubjectService {
 
         UserFeignResponse teacher = userClient.getTeacherSimpleById(request.teacherId());
 
-        return self.createTransactional(request, id, teacher);
+        TeacherSubjectResponse response = self.createTransactional(request, id, teacher);
+        log.info("TeacherSubject created: request={}", request);
+        return response;
     }
 
     @Transactional
@@ -105,6 +109,7 @@ public class TeacherSubjectService {
         }
 
         teacherSubjectRepository.softDelete(id.getSubjectId(), id.getTeacherId());
+        log.info("TeacherSubject deleted: request={}", request);
     }
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/report/GradeReportService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/report/GradeReportService.java
@@ -16,6 +16,7 @@ import com.rusobr.academic.web.dto.pdf.StudentPeriodFinalGradeReportDto;
 import com.rusobr.academic.web.dto.pdf.TeacherGradeReportDto;
 import com.rusobr.academic.web.dto.schoolClass.SchoolClassResponse;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
+import com.rusobr.academic.web.exception.BadRequestException;
 import com.rusobr.common.dto.UserFeignResponse;
 import com.rusobr.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +40,7 @@ public class GradeReportService {
     private final AcademicYearService academicYearService;
 
     public StudentGradeReportDto getStudentGradeReport(Long studentId, Long periodId) {
-        var student = userClient.getBatchStudents(List.of(studentId)).found().get(0);
+        UserFeignResponse student = fetchStudentOrThrow(studentId);
         var journal = journalService.getGradesByStudentId(studentId, periodId);
         var schoolClass = schoolClassService.findByStudent(studentId);
 
@@ -70,7 +71,7 @@ public class GradeReportService {
 
     public StudentPeriodFinalGradeReportDto getStudentPeriodFinalGradeReport(Long studentId, Long academicYearId) {
         AcademicYearResponse academicYear = academicYearService.findById(academicYearId);
-        UserFeignResponse student = userClient.getBatchStudents(List.of(studentId)).found().get(0);
+        UserFeignResponse student = fetchStudentOrThrow(studentId);
         SchoolClassResponse schoolClass = schoolClassService.findByStudent(studentId);
         List<PeriodFinalGradeResponse> periodFinalGrades = journalService.getPeriodFinalGrades(studentId, academicYearId);
 
@@ -94,6 +95,14 @@ public class GradeReportService {
                 .title("Табель успеваемости учеников")
                 .teacher(teacher)
                 .journal(journal).build();
+    }
+
+    private UserFeignResponse fetchStudentOrThrow(Long studentId) {
+        List<UserFeignResponse> found = userClient.getBatchStudents(List.of(studentId)).found();
+        if (found.isEmpty()) {
+            throw new BadRequestException("Student not found with id: %s".formatted(studentId), AcademicExceptionCode.PDF_EXPORT_ERROR);
+        }
+        return found.get(0);
     }
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/application/service/report/PdfReportService.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/application/service/report/PdfReportService.java
@@ -37,19 +37,15 @@ public class PdfReportService {
             builder.useFastMode();
             builder.withHtmlContent(html, null);
 
-            InputStream regularFont =
-                    getClass().getResourceAsStream("/fonts/PTSans-Regular.ttf");
-            InputStream boldFont =
-                    getClass().getResourceAsStream("/fonts/PTSans-Bold.ttf");
             builder.useFont(
-                    () -> regularFont,
+                    () -> getClass().getResourceAsStream("/fonts/PTSans-Regular.ttf"),
                     "PT Sans",
                     400,
                     PdfRendererBuilder.FontStyle.NORMAL,
                     true
             );
             builder.useFont(
-                    () -> boldFont,
+                    () -> getClass().getResourceAsStream("/fonts/PTSans-Bold.ttf"),
                     "PT Sans",
                     700,
                     PdfRendererBuilder.FontStyle.NORMAL,
@@ -60,7 +56,7 @@ public class PdfReportService {
             builder.run();
             return os.toByteArray();
         } catch (IOException e) {
-            throw new ReportGenerationException("Не удалось сформировать PDF-отчёт");
+            throw new ReportGenerationException("Не удалось сформировать PDF-отчёт", e);
         }
     }
 

--- a/backend/academic-service/src/main/java/com/rusobr/academic/config/security/GradeSecurity.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/config/security/GradeSecurity.java
@@ -1,33 +1,20 @@
 package com.rusobr.academic.config.security;
 
 import com.rusobr.academic.infrastructure.persistence.repository.GradeRepository;
-import com.rusobr.academic.infrastructure.persistence.repository.TeachingAssignmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("gradeSecurity")
 @RequiredArgsConstructor
 public class GradeSecurity {
 
     private final GradeRepository gradeRepository;
-    private final TeachingAssignmentRepository teachingAssignmentRepository;
 
     public boolean canViewStudent(Long gradeId, Authentication auth) {
         Long userId = ((Jwt) auth.getPrincipal()).getClaim("user_id");
-
         return gradeRepository.existsByIdAndStudentId(gradeId, userId);
-    }
-
-    public boolean canViewAssignment(Long teachingAssignmentId, Authentication auth) {
-        Long userId = ((Jwt) auth.getPrincipal()).getClaim("user_id");
-        List<Long> teachingAssignmentIds = teachingAssignmentRepository
-                .getTeachingAssignmentIdsByTeacherId(userId);
-
-        return teachingAssignmentIds.contains(teachingAssignmentId);
     }
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/config/security/TeacherSecurity.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/config/security/TeacherSecurity.java
@@ -1,0 +1,94 @@
+package com.rusobr.academic.config.security;
+
+import com.rusobr.academic.infrastructure.persistence.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component("teacherSecurity")
+@RequiredArgsConstructor
+public class TeacherSecurity {
+
+    private final TeachingAssignmentRepository teachingAssignmentRepository;
+    private final LessonInstanceRepository lessonInstanceRepository;
+    private final GradeRepository gradeRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final HomeworkRepository homeworkRepository;
+    private final PeriodGradeRepository periodGradeRepository;
+    private final FinalGradeRepository finalGradeRepository;
+
+    public boolean canViewAssignment(Long teachingAssignmentId, Authentication auth) {
+        Long teacherId = currentTeacherId(auth);
+        return teachingAssignmentRepository
+                .isTeacherOwnedAssignment(teacherId, teachingAssignmentId);
+    }
+
+    //GRADE
+    public boolean canCreateGrade(Long studentId, Long lessonInstanceId, Authentication auth) {
+        Long teacherId = currentTeacherId(auth);
+        return lessonInstanceRepository.isOwnedByTeacherAndHasStudent(teacherId, lessonInstanceId, studentId);
+    }
+
+    public boolean canDeleteGrade(Long gradeId, Authentication auth) {
+        Long teacherId = currentTeacherId(auth);
+        return gradeRepository.isGradeOwnedByTeacher(teacherId, gradeId);
+    }
+
+    //ATTENDANCE
+    public boolean canCreateAttendance(Long studentId, Long lessonInstanceId, Authentication auth) {
+        Long teacherId = currentTeacherId(auth);
+        return lessonInstanceRepository.isOwnedByTeacherAndHasStudent(teacherId, lessonInstanceId, studentId);
+    }
+
+    public boolean canDeleteAttendance(Long attendanceId, Authentication auth) {
+        Long teacherId = currentTeacherId(auth);
+        return attendanceRepository.isAttendanceOwnedByTeacher(teacherId, attendanceId);
+    }
+
+    //HOMEWORK
+    public boolean canCreateHomework(Long lessonInstanceId, Authentication auth) {
+        Long teacherId = currentTeacherId(auth);
+        return lessonInstanceRepository.isOwnedByTeacher(teacherId, lessonInstanceId);
+    }
+
+    public boolean canDeleteHomework(Long homeworkId, Authentication auth) {
+        Long teacherId = currentTeacherId(auth);
+        return homeworkRepository.isHomeworkOwnedByTeacher(teacherId, homeworkId);
+    }
+
+    //PERIOD-GRADE
+    public boolean canCreatePeriodGrade(Long teachingAssignmentId, Long studentId, Authentication auth) {
+        Long teacherId = currentTeacherId(auth);
+        return teachingAssignmentRepository.isOwnedByTeacherWithStudent(teacherId, teachingAssignmentId, studentId);
+    }
+
+    public boolean canDeletePeriodGrade(Long periodGradeId, Authentication auth) {
+        Long teacherId = currentTeacherId(auth);
+        return periodGradeRepository.isPeriodGradeOwnedByTeacher(teacherId, periodGradeId);
+    }
+
+    //FINAL-GRADE
+    public boolean canCreateFinalGrade(Long teachingAssignmentId, Long studentId, Authentication auth) {
+        Long teacherId = currentTeacherId(auth);
+        return teachingAssignmentRepository.isOwnedByTeacherWithStudent(teacherId, teachingAssignmentId, studentId);
+    }
+
+    public boolean canDeleteFinalGrade(Long finalGradeId, Authentication auth) {
+        Long teacherId = currentTeacherId(auth);
+        return finalGradeRepository.isFinalGradeOwnedByTeacher(teacherId, finalGradeId);
+    }
+
+
+    //helpers
+    private Long currentTeacherId(Authentication auth) {
+        Long teacherId = ((Jwt) auth.getPrincipal()).getClaim("user_id");
+        if (teacherId == null) {
+            throw new IllegalStateException("JWT claim 'user_id' is missing");
+        }
+        return teacherId;
+    }
+
+}

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/AttendanceRepository.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/AttendanceRepository.java
@@ -2,11 +2,26 @@ package com.rusobr.academic.infrastructure.persistence.repository;
 
 import com.rusobr.academic.domain.model.Attendance;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface AttendanceRepository extends JpaRepository<Attendance,Long> {
+
     Optional<Attendance> findByStudentIdAndLessonInstanceId(Long studentId, Long lessonInstanceId);
+
+    @Query("""
+        select count(*) > 0
+        from Attendance a
+            join a.lessonInstance li
+            join li.scheduleLesson sl
+            join sl.teachingAssignment ta
+        where ta.teacherId = :teacherId
+        and a.id = :gradeId
+    """)
+    boolean isAttendanceOwnedByTeacher(@Param("teacherId") Long teacherId, @Param("attendanceId") Long attendanceId);
+
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/AttendanceRepository.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/AttendanceRepository.java
@@ -1,6 +1,8 @@
 package com.rusobr.academic.infrastructure.persistence.repository;
 
 import com.rusobr.academic.domain.model.Attendance;
+import com.rusobr.academic.domain.model.Grade;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,5 +25,8 @@ public interface AttendanceRepository extends JpaRepository<Attendance,Long> {
         and a.id = :gradeId
     """)
     boolean isAttendanceOwnedByTeacher(@Param("teacherId") Long teacherId, @Param("attendanceId") Long attendanceId);
+
+    @EntityGraph(attributePaths = {"lessonInstance"})
+    Optional<Attendance> findWithLessonInstanceById(Long id);
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/FinalGradeRepository.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/FinalGradeRepository.java
@@ -4,6 +4,7 @@ import com.rusobr.academic.domain.model.FinalGrade;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,4 +36,14 @@ public interface FinalGradeRepository extends JpaRepository<FinalGrade, Long> {
 
     @EntityGraph(attributePaths = {"academicYear"})
     Optional<FinalGrade> findWithAcademicYearById(Long id);
+
+    @Query("""
+        select count(*) > 0
+        from FinalGrade fg
+            join fg.teachingAssignment ta
+        where ta.teacherId = :teacherId
+        and fg.id = :finalGradeId
+""")
+    boolean isFinalGradeOwnedByTeacher(@Param("teacherId") Long teacherId, @Param("finalGradeId") Long finalGradeId);
+
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/GradeRepository.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/GradeRepository.java
@@ -101,4 +101,16 @@ public interface GradeRepository extends JpaRepository<Grade, Long> {
     Optional<GradeDetailProjection> findDetailById(@Param("id") Long id);
 
     boolean existsByIdAndStudentId(Long id, Long studentId);
+
+    @Query("""
+        select count(*) > 0
+        from Grade g
+            join g.lessonInstance li
+            join li.scheduleLesson sl
+            join sl.teachingAssignment ta
+        where ta.teacherId = :teacherId
+        and g.id = :gradeId
+""")
+    boolean isGradeOwnedByTeacher(@Param("teacherId") Long teacherId, @Param("gradeId") Long gradeId);
+
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/HomeworkRepository.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/HomeworkRepository.java
@@ -47,4 +47,16 @@ public interface HomeworkRepository extends CrudRepository<Homework, Long> {
 
     @EntityGraph(attributePaths = {"lessonInstance"})
     Optional<Homework> findWithLessonInstanceById(Long id);
+
+    @Query("""
+        select count(*) > 0
+        from Homework h
+            join h.lessonInstance li
+            join li.scheduleLesson sl
+            join sl.teachingAssignment ta
+        where ta.teacherId = :teacherId
+        and h.id = :homeworkId
+    """)
+    boolean isHomeworkOwnedByTeacher(@Param("teacherId") Long teacherId, @Param("homeworkId") Long homeworkId);
+
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/LessonInstanceRepository.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/LessonInstanceRepository.java
@@ -169,4 +169,30 @@ public interface LessonInstanceRepository extends JpaRepository<LessonInstance, 
                                                                  @Param("endDate") LocalDate endDate,
                                                                  @Param("studentId") Long studentId);
 
+    @Query("""
+        select count(*) > 0
+            from LessonInstance li
+            join li.scheduleLesson sl
+            join sl.teachingAssignment ta
+            join ta.schoolClass sc
+            join sc.students cs
+            where cs.studentId = :studentId
+            and li.id = :lessonInstanceId
+            and ta.teacherId = :teacherId
+    """)
+    boolean isOwnedByTeacherAndHasStudent(@Param("teacherId") Long teacherId,
+                                                       @Param("lessonInstanceId") Long lessonInstanceId,
+                                                       @Param("studentId") Long studentId);
+
+    @Query("""
+        select count(*) > 0
+            from LessonInstance li
+            join li.scheduleLesson sl
+            join sl.teachingAssignment ta
+            where li.id = :lessonInstanceId
+            and ta.teacherId = :teacherId
+    """)
+    boolean isOwnedByTeacher(@Param("teacherId") Long teacherId,
+                                          @Param("lessonInstanceId") Long lessonInstanceId);
+
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/PeriodGradeRepository.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/PeriodGradeRepository.java
@@ -1,7 +1,6 @@
 package com.rusobr.academic.infrastructure.persistence.repository;
 
 import com.rusobr.academic.domain.model.PeriodGrade;
-import com.rusobr.academic.infrastructure.persistence.projection.PeriodGradeProjection;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -43,5 +42,14 @@ public interface PeriodGradeRepository extends CrudRepository<PeriodGrade, Long>
 """)
     List<PeriodGrade> findPeriodGradesByTeachingAssignmentId(@Param("teachingAssignmentId") Long teachingAssignmentId,
                                                              @Param("academicYearId") Long academicYearId);
+
+    @Query("""
+        select count(*) > 0
+        from PeriodGrade pg
+            join pg.teachingAssignment ta
+        where ta.teacherId = :teacherId
+        and pg.id = :gradeId
+""")
+    boolean isPeriodGradeOwnedByTeacher(@Param("teacherId") Long teacherId, @Param("periodGradeId") Long periodGradeId);
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/TeachingAssignmentRepository.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/TeachingAssignmentRepository.java
@@ -2,7 +2,6 @@ package com.rusobr.academic.infrastructure.persistence.repository;
 
 import com.rusobr.academic.domain.model.TeachingAssignment;
 import com.rusobr.academic.infrastructure.persistence.projection.TeachingAssignmentDetailsProjection;
-import com.rusobr.academic.web.dto.teachingAssignment.TeachingAssignmentDetailsDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -54,9 +53,22 @@ public interface TeachingAssignmentRepository  extends JpaRepository<TeachingAss
     List<TeachingAssignment> findByTeacherId(@Param("teacherId") Long teacherId);
 
     @Query("""
-        select ta.id
+        select count(*) > 0
         from TeachingAssignment ta
         where ta.teacherId = :teacherId
+            and ta.id = :teachingAssignmentId
     """)
-    List<Long> getTeachingAssignmentIdsByTeacherId(@Param("teacherId") Long teacherId);
+    boolean isTeacherOwnedAssignment(@Param("teacherId") Long teacherId, @Param("teachingAssignmentId") Long teachingAssignmentId);
+
+    @Query("""
+        select count(*) > 0
+        from TeachingAssignment ta
+            join ta.schoolClass sc
+            join sc.students cs
+        where ta.teacherId = :teacherId
+        and ta.id = :teachingAssignmentId
+        and cs.studentId = :studentId
+    """)
+    boolean isOwnedByTeacherWithStudent(@Param("teacherId") Long teacherId, @Param("teachingAssignmentId") Long teachingAssignmentId, @Param("studentId") Long studentId);
+
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/AttendanceController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/AttendanceController.java
@@ -3,7 +3,10 @@ package com.rusobr.academic.web.controller;
 import com.rusobr.academic.application.service.AttendanceService;
 import com.rusobr.academic.web.dto.attendances.AttendanceRequest;
 import com.rusobr.academic.web.dto.attendances.AttendanceResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,13 +16,17 @@ public class AttendanceController {
 
     private final AttendanceService attendanceService;
 
+    @PreAuthorize("@teacherSecurity.canCreateAttendance(#attendanceRequest.studentId(), #attendanceRequest.lessonInstanceId(), authentication)")
     @PostMapping
-    public AttendanceResponse createAttendance(@RequestBody AttendanceRequest attendanceRequest) {
+    @ResponseStatus(HttpStatus.CREATED)
+    public AttendanceResponse create(@RequestBody @Valid AttendanceRequest attendanceRequest) {
         return attendanceService.create(attendanceRequest);
     }
 
+    @PreAuthorize("@teacherSecurity.canDeleteAttendance(#id, authentication)")
     @DeleteMapping("/{id}")
-    public void deleteAttendance(@PathVariable Long id) {
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
         attendanceService.delete(id);
     }
 

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/FinalGradeController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/FinalGradeController.java
@@ -5,6 +5,7 @@ import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeCreateResponse;
 import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeRequest;
 import com.rusobr.academic.web.dto.grade.finalGrade.FinalGradeTeacherResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,25 +16,23 @@ public class FinalGradeController {
 
     private final FinalGradeService finalGradeService;
 
-//    @GetMapping("/by-student")
-//    public Map<String, FinalGradeResponse> getByStudentId(@AuthenticationPrincipal Jwt jwt, @RequestParam Long academicYearId) {
-//        Long userId = jwt.getClaim("user_id");
-//        return finalGradeService.getByStudentId(userId, academicYearId);
-//    }
-
-    @PreAuthorize("@gradeSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
+    @PreAuthorize("@teacherSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
     @GetMapping("/by-assignment")
     public FinalGradeTeacherResponse getByAssignmentId(@RequestParam Long teachingAssignmentId,
                                                        @RequestParam Long academicYearId) {
         return finalGradeService.getByAssignmentId(teachingAssignmentId, academicYearId);
     }
 
+    @PreAuthorize("@teacherSecurity.canCreateFinalGrade(#finalGradeRequest.teachingAssignmentId(), #finalGradeRequest.studentId(), authentication)")
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     public FinalGradeCreateResponse create(@RequestBody FinalGradeRequest finalGradeRequest) {
         return finalGradeService.create(finalGradeRequest);
     }
 
+    @PreAuthorize("@teacherSecurity.canDeleteFinalGrade(#id, authentication)")
     @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
         finalGradeService.delete(id);
     }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/GradeController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/GradeController.java
@@ -8,6 +8,7 @@ import com.rusobr.academic.web.dto.grade.createGrade.CreateGradeResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,12 +31,16 @@ public class GradeController {
         return gradeService.getDetail(id);
     }
 
+    @PreAuthorize("@teacherSecurity.canCreateGrade(#createGradeRequest.studentId(), createGradeRequest.lessonInstanceId(), authentication)")
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     public CreateGradeResponse create(@RequestBody @Valid CreateGradeRequest createGradeRequest) {
         return gradeService.create(createGradeRequest);
     }
 
+    @PreAuthorize("@teacherSecurity.canDeleteGrade(#id, authentication)")
     @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
         gradeService.delete(id);
     }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/HomeworkController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/HomeworkController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,18 +18,22 @@ public class HomeworkController {
 
     private final HomeworkService homeworkService;
 
-    @PreAuthorize("@gradeSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
+    @PreAuthorize("@teacherSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
     @GetMapping("/by-assignment")
     public Page<HomeworkResponse> getByAssignment(@RequestParam Long teachingAssignmentId, Pageable pageable) {
         return homeworkService.getByAssignment(teachingAssignmentId, pageable);
     }
 
+    @PreAuthorize("@teacherSecurity.canCreateHomework(#homeworkRequest.lessonInstanceId(), authentication)")
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     public HomeworkResponse create(@RequestBody @Valid HomeworkRequest homeworkRequest) {
         return homeworkService.create(homeworkRequest);
     }
 
+    @PreAuthorize("@teacherSecurity.canDeleteHomework(#id, authentication)")
     @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
         homeworkService.delete(id);
     }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/JournalController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/JournalController.java
@@ -37,7 +37,7 @@ public class JournalController {
         return journalService.getPeriodFinalGrades(userId, academicYearId);
     }
 
-    @PreAuthorize("@gradeSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
+    @PreAuthorize("@teacherSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
     @GetMapping("/journal/by-assignment")
     public TeacherJournalResponse getByAssignment(
             @RequestParam("teachingAssignmentId") Long teachingAssignmentId,
@@ -45,7 +45,7 @@ public class JournalController {
         return journalService.getJournalByAssignment(teachingAssignmentId, academicPeriodId);
     }
 
-    @PreAuthorize("@gradeSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
+    @PreAuthorize("@teacherSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
     @GetMapping("/lesson-instances/by-assignment")
     public List<LessonInstanceDto> getInstanceByAssignment(@RequestParam("teachingAssignmentId") Long teachingAssignmentId,
                                                            @RequestParam("academicPeriodId") Long academicPeriodId) {

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/PdfExportController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/PdfExportController.java
@@ -51,7 +51,7 @@ public class PdfExportController {
                 .body(pdf);
     }
 
-    @PreAuthorize("@gradeSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
+    @PreAuthorize("@teacherSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
     @GetMapping(value = "/teacher/student-grade-report/report", produces = MediaType.APPLICATION_PDF_VALUE)
     public ResponseEntity<byte[]> teacherGradeReport(@RequestParam Long teachingAssignmentId, @RequestParam Long periodId) {
         TeacherGradeReportDto data = gradeReportService.getTeacherGradeReport(teachingAssignmentId, periodId);

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/PeriodGradeController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/PeriodGradeController.java
@@ -4,6 +4,7 @@ import com.rusobr.academic.application.service.PeriodGradeService;
 import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeRequest;
 import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeResponse;
 import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeTeacherResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -26,12 +27,12 @@ public class PeriodGradeController {
     @PreAuthorize("@teacherSecurity.canCreatePeriodGrade(#periodGradeRequest.teachingAssignmentId(), #periodGradeRequest.studentId(), authentication)")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public PeriodGradeResponse createPeriodGrade(@RequestBody PeriodGradeRequest periodGradeRequest) {
+    public PeriodGradeResponse createPeriodGrade(@RequestBody @Valid PeriodGradeRequest periodGradeRequest) {
         return periodGradeService.create(periodGradeRequest);
     }
 
 
-    @PreAuthorize("@teacherSecurity.canDeletePeriodGrade(#periodGradeRequest.teachingAssignmentId(), #periodGradeRequest.studentId(), authentication)")
+    @PreAuthorize("@teacherSecurity.canDeletePeriodGrade(#id, authentication)")
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deletePeriodGrade(@PathVariable Long id) {

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/PeriodGradeController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/PeriodGradeController.java
@@ -1,16 +1,13 @@
 package com.rusobr.academic.web.controller;
 
 import com.rusobr.academic.application.service.PeriodGradeService;
-import com.rusobr.academic.web.dto.grade.periodGrade.*;
+import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeRequest;
+import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeResponse;
+import com.rusobr.academic.web.dto.grade.periodGrade.PeriodGradeTeacherResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,14 +15,7 @@ import java.util.Map;
 public class PeriodGradeController {
     private final PeriodGradeService periodGradeService;
 
-//    @GetMapping("/by-student")
-//    public Map<String, List<PeriodGradeStudentResponse>> getByStudentId(@AuthenticationPrincipal Jwt jwt,
-//                                                                        @RequestParam Long academicYearId) {
-//        Long userId = jwt.getClaim("user_id");
-//        return periodGradeService.getByStudentId(userId, academicYearId);
-//    }
-
-    @PreAuthorize("@gradeSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
+    @PreAuthorize("@teacherSecurity.canViewAssignment(#teachingAssignmentId, authentication)")
     @GetMapping("/by-assignment")
     public PeriodGradeTeacherResponse getGradesByAssignment(@RequestParam Long teachingAssignmentId,
                                                                      @RequestParam Long currentAcademicPeriodId,
@@ -33,12 +23,15 @@ public class PeriodGradeController {
         return periodGradeService.getByAssignmentWithAverage(teachingAssignmentId, currentAcademicPeriodId, academicYearId);
     }
 
+    @PreAuthorize("@teacherSecurity.canCreatePeriodGrade(#periodGradeRequest.teachingAssignmentId(), #periodGradeRequest.studentId(), authentication)")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public PeriodGradeResponse createPeriodGrade(@RequestBody PeriodGradeRequest periodGradeRequest) {
         return periodGradeService.create(periodGradeRequest);
     }
 
+
+    @PreAuthorize("@teacherSecurity.canDeletePeriodGrade(#periodGradeRequest.teachingAssignmentId(), #periodGradeRequest.studentId(), authentication)")
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deletePeriodGrade(@PathVariable Long id) {

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/grade/createGrade/CreateGradeRequest.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/grade/createGrade/CreateGradeRequest.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.NotNull;
 public record CreateGradeRequest(
         @NotNull Long studentId,
         @NotNull Long lessonInstanceId,
-        @NotNull Long academicPeriodId,
         @NotNull Integer value,
         @NotNull Integer weight,
         @NotNull GradeType gradeType

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/grade/periodGrade/PeriodGradeRequest.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/dto/grade/periodGrade/PeriodGradeRequest.java
@@ -1,10 +1,12 @@
 package com.rusobr.academic.web.dto.grade.periodGrade;
 
+import jakarta.validation.constraints.NotNull;
+
 public record PeriodGradeRequest(
-        Integer value,
+        @NotNull Integer value,
         String description,
-        Long teachingAssignmentId,
-        Long studentId,
-        Long academicPeriodId
+        @NotNull Long teachingAssignmentId,
+        @NotNull Long studentId,
+        @NotNull Long academicPeriodId
 ) {
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/exception/AcademicExceptionCode.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/exception/AcademicExceptionCode.java
@@ -27,6 +27,7 @@ public enum AcademicExceptionCode implements IExceptionCode {
     FINAL_GRADE_NOT_FOUND,
 
     GRADE_NOT_FOUND,
+    ATTENDANCE_NOT_FOUND,
 
     TEACHING_ASSIGNMENT_NOT_FOUND,
 
@@ -55,8 +56,12 @@ public enum AcademicExceptionCode implements IExceptionCode {
     USER_SERVICE_FORBIDDEN,
     USER_SERVICE_UNAUTHORIZED,
 
+    ACCESS_DENIED,
+
     DB_VALIDATION_ERROR,
     VALIDATION_ERROR,
 
-    PDF_EXPORT_ERROR
+    PDF_EXPORT_ERROR,
+
+    UNHANDLED_SERVER_ERROR
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/exception/AcademicExceptionCode.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/exception/AcademicExceptionCode.java
@@ -57,4 +57,6 @@ public enum AcademicExceptionCode implements IExceptionCode {
 
     DB_VALIDATION_ERROR,
     VALIDATION_ERROR,
+
+    PDF_EXPORT_ERROR
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/exception/GlobalExceptionHandler.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/exception/GlobalExceptionHandler.java
@@ -5,9 +5,11 @@ import com.rusobr.common.exception.ForbiddenException;
 import com.rusobr.common.exception.NotFoundException;
 import com.rusobr.common.exception.UnauthorizedException;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -17,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException ex, HttpServletRequest req) {
@@ -104,10 +107,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<ErrorResponse> handleDbValidationError(DataIntegrityViolationException ex, HttpServletRequest req) {
 
+        log.error("DataIntegrityViolationException DB_VALIDATION_ERROR", ex);
+
         ErrorResponse errorResponse = new ErrorResponse(
                 LocalDateTime.now(),
                 HttpStatus.CONFLICT.value(),
-                ex.getMessage(),
+                "Database error",
                 AcademicExceptionCode.DB_VALIDATION_ERROR,
                 req.getRequestURI()
         );
@@ -131,6 +136,38 @@ public class GlobalExceptionHandler {
         );
 
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex, HttpServletRequest req) {
+
+        log.warn("Access denied: uri={}", req.getRequestURI());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.FORBIDDEN.value(),
+                "Доступ запрещён",
+                AcademicExceptionCode.ACCESS_DENIED,
+                req.getRequestURI()
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnhandledException(Exception ex, HttpServletRequest req) {
+
+        log.error("INTERNAL SERVER ERROR", ex);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "Ошибка сервера 500",
+                AcademicExceptionCode.UNHANDLED_SERVER_ERROR,
+                req.getRequestURI()
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/exception/ReportGenerationException.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/exception/ReportGenerationException.java
@@ -1,9 +1,7 @@
 package com.rusobr.academic.web.exception;
 
-import java.io.IOException;
-
 public class ReportGenerationException extends RuntimeException {
-    public ReportGenerationException(String message) {
-        super(message);
+    public ReportGenerationException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/backend/academic-service/src/test/java/com/rusobr/academic/controller/AttendanceControllerTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/controller/AttendanceControllerTest.java
@@ -64,15 +64,15 @@ public class AttendanceControllerTest {
     }
 
     @Test
-    @DisplayName("POST /attendances — 200 и созданное посещение")
-    void createAttendance_ShouldReturn200() throws Exception {
+    @DisplayName("POST /attendances — 201 и созданное посещение")
+    void createAttendance_ShouldReturn201() throws Exception {
         AttendanceRequest request = buildRequest();
         when(attendanceService.create(request)).thenReturn(buildResponse());
 
         mockMvc.perform(post("/api/v1/attendances")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.attendanceId").value(ATTENDANCE_ID))
                 .andExpect(jsonPath("$.studentId").value(STUDENT_ID))
                 .andExpect(jsonPath("$.status").value("LATE"))
@@ -109,12 +109,12 @@ public class AttendanceControllerTest {
     }
 
     @Test
-    @DisplayName("DELETE /attendances/{id} — 200 при успешном удалении")
-    void deleteAttendance_ShouldReturn200() throws Exception {
+    @DisplayName("DELETE /attendances/{id} — 204 при успешном удалении")
+    void deleteAttendance_ShouldReturn204() throws Exception {
         doNothing().when(attendanceService).delete(ATTENDANCE_ID);
 
         mockMvc.perform(delete("/api/v1/attendances/{id}", ATTENDANCE_ID))
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
 
         verify(attendanceService).delete(ATTENDANCE_ID);
     }

--- a/backend/academic-service/src/test/java/com/rusobr/academic/controller/FinalGradeControllerTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/controller/FinalGradeControllerTest.java
@@ -133,15 +133,15 @@ public class FinalGradeControllerTest {
     }
 
     @Test
-    @DisplayName("POST /final-grades — 200 and created grade")
-    void create_ShouldReturn200() throws Exception {
+    @DisplayName("POST /final-grades — 201 and created grade")
+    void create_ShouldReturn201() throws Exception {
         FinalGradeRequest request = buildRequest();
         when(finalGradeService.create(request)).thenReturn(buildCreateResponse());
 
         mockMvc.perform(post("/api/v1/final-grades")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(FINAL_GRADE_ID))
                 .andExpect(jsonPath("$.studentId").value(STUDENT_ID))
                 .andExpect(jsonPath("$.value").value(5))
@@ -163,12 +163,12 @@ public class FinalGradeControllerTest {
     }
 
     @Test
-    @DisplayName("DELETE /final-grades/{id} — 200 on success")
-    void delete_ShouldReturn200() throws Exception {
+    @DisplayName("DELETE /final-grades/{id} — 204 on success")
+    void delete_ShouldReturn204() throws Exception {
         doNothing().when(finalGradeService).delete(FINAL_GRADE_ID);
 
         mockMvc.perform(delete("/api/v1/final-grades/{id}", FINAL_GRADE_ID))
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
 
         verify(finalGradeService).delete(FINAL_GRADE_ID);
     }

--- a/backend/academic-service/src/test/java/com/rusobr/academic/controller/GradeControllerTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/controller/GradeControllerTest.java
@@ -46,7 +46,6 @@ public class GradeControllerTest {
 
     private static final Long GRADE_ID = 1L;
     private static final Long STUDENT_ID = 10L;
-    private static final Long PERIOD_ID = 5L;
     private static final Long LESSON_ID = 100L;
     private static final LocalDate DATE = LocalDate.of(2026, 10, 20);
 
@@ -55,7 +54,7 @@ public class GradeControllerTest {
     }
 
     private CreateGradeRequest buildCreateRequest() {
-        return new CreateGradeRequest(STUDENT_ID, LESSON_ID, PERIOD_ID, 5, 2, GradeType.TEST);
+        return new CreateGradeRequest(STUDENT_ID, LESSON_ID, 5, 2, GradeType.TEST);
     }
 
     private CreateGradeResponse buildCreateResponse() {
@@ -87,15 +86,15 @@ public class GradeControllerTest {
     }
 
     @Test
-    @DisplayName("POST /grades — 200 and created grade")
-    void create_ShouldReturn200() throws Exception {
+    @DisplayName("POST /grades — 201 and created grade")
+    void create_ShouldReturn201() throws Exception {
         CreateGradeRequest request = buildCreateRequest();
         when(gradeService.create(request)).thenReturn(buildCreateResponse());
 
         mockMvc.perform(post("/api/v1/grades")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.gradeId").value(GRADE_ID))
                 .andExpect(jsonPath("$.studentId").value(STUDENT_ID))
                 .andExpect(jsonPath("$.lessonInstance.id").value(LESSON_ID))
@@ -120,12 +119,12 @@ public class GradeControllerTest {
     }
 
     @Test
-    @DisplayName("DELETE /grades/{id} — 200 on success")
-    void delete_ShouldReturn200() throws Exception {
+    @DisplayName("DELETE /grades/{id} — 204 on success")
+    void delete_ShouldReturn204() throws Exception {
         doNothing().when(gradeService).delete(GRADE_ID);
 
         mockMvc.perform(delete("/api/v1/grades/{id}", GRADE_ID))
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
 
         verify(gradeService).delete(GRADE_ID);
     }

--- a/backend/academic-service/src/test/java/com/rusobr/academic/controller/HomeworkControllerTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/controller/HomeworkControllerTest.java
@@ -80,15 +80,15 @@ public class HomeworkControllerTest {
     }
 
     @Test
-    @DisplayName("POST /homeworks — 200 and created homework")
-    void create_ShouldReturn200() throws Exception {
+    @DisplayName("POST /homeworks — 201 and created homework")
+    void create_ShouldReturn201() throws Exception {
         HomeworkRequest request = buildHomeworkRequest();
         when(homeworkService.create(request)).thenReturn(buildHomeworkResponse());
 
         mockMvc.perform(post("/api/v1/homeworks")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(HOMEWORK_ID))
                 .andExpect(jsonPath("$.text").value("Read chapter 5"))
                 .andExpect(jsonPath("$.lessonInstance.id").value(LESSON_INSTANCE_ID))
@@ -96,12 +96,12 @@ public class HomeworkControllerTest {
     }
 
     @Test
-    @DisplayName("DELETE /homeworks/{id} — 200 on success")
-    void delete_ShouldReturn200() throws Exception {
+    @DisplayName("DELETE /homeworks/{id} — 204 on success")
+    void delete_ShouldReturn204() throws Exception {
         doNothing().when(homeworkService).delete(HOMEWORK_ID);
 
         mockMvc.perform(delete("/api/v1/homeworks/{id}", HOMEWORK_ID))
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
 
         verify(homeworkService).delete(HOMEWORK_ID);
     }

--- a/backend/academic-service/src/test/java/com/rusobr/academic/controller/ScheduleControllerTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/controller/ScheduleControllerTest.java
@@ -9,6 +9,9 @@ import com.rusobr.academic.web.dto.scheduleLesson.ScheduleLessonDto;
 import com.rusobr.academic.web.dto.scheduleLesson.ScheduleLessonRequest;
 import com.rusobr.academic.web.dto.scheduleLesson.ScheduleLessonResponse;
 import com.rusobr.academic.web.dto.scheduleLesson.SchoolLessonResponse;
+import com.rusobr.academic.web.dto.scheduleLesson.studentDiary.DiaryDayDto;
+import com.rusobr.academic.web.dto.scheduleLesson.studentDiary.DiaryLessonDto;
+import com.rusobr.academic.web.dto.scheduleLesson.studentDiary.DiaryWeekResponse;
 import com.rusobr.academic.web.dto.subject.SubjectResponseDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -69,16 +72,24 @@ public class ScheduleControllerTest {
         return new ScheduleLessonResponse(SCHEDULE_ID, 2, "Mathematics", "101");
     }
 
-    private DiaryScheduleDto buildDiaryScheduleDto() {
-        return new DiaryScheduleDto(
-                SCHEDULE_ID,
-                DayOfWeek.MONDAY,
-                2,
-                "101",
+    private DiaryWeekResponse buildDiaryWeekResponse() {
+        return new DiaryWeekResponse(
                 DATE,
-                DATE.plusWeeks(1),
-                new SubjectResponseDto(SUBJECT_ID, "Mathematics"),
-                null
+                DATE.plusDays(1),
+                List.of(new DiaryDayDto(
+                        DayOfWeek.MONDAY,
+                        DATE,
+                        List.of(new DiaryLessonDto(
+                                2,
+                                new SubjectResponseDto(SUBJECT_ID, "Mathematics"),
+                                SCHEDULE_ID,
+                                500L,
+                                "101",
+                                List.of(),
+                                null,
+                                List.of()
+                        ))
+                ))
         );
     }
 
@@ -112,17 +123,18 @@ public class ScheduleControllerTest {
     }
 
     @Test
-    @DisplayName("GET /schedules/diary — 200 and diary schedule list")
+    @DisplayName("GET /schedules/diary — 200 and diary week response")
     void getDiaryScheduleByStudentId_ShouldReturn200() throws Exception {
         when(scheduleService.getByStudentId(STUDENT_ID, DATE, DATE.plusDays(1)))
-                .thenReturn(List.of(buildDiaryScheduleDto()));
+                .thenReturn(buildDiaryWeekResponse());
 
         mockMvc.perform(get("/api/v1/schedules/diary")
                         .param("startDate", DATE.toString())
                         .param("endDate", DATE.plusDays(1).toString()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].id").value(SCHEDULE_ID))
-                .andExpect(jsonPath("$[0].subject.name").value("Mathematics"));
+                .andExpect(jsonPath("$.days[0].lessons[0].id").doesNotExist())
+                .andExpect(jsonPath("$.days[0].lessons[0].scheduleId").value(SCHEDULE_ID))
+                .andExpect(jsonPath("$.days[0].lessons[0].subject.name").value("Mathematics"));
     }
 
     @Test

--- a/backend/academic-service/src/test/java/com/rusobr/academic/service/AttendanceServiceTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/service/AttendanceServiceTest.java
@@ -170,9 +170,53 @@ class AttendanceServiceTest {
         @Test
         @DisplayName("успешно вызывает удаление из репозитория по id")
         void success() {
+            LessonInstance lessonInstance = LessonInstance.builder().id(LESSON_INSTANCE_ID).lessonDate(LESSON_DATE).build();
+            Attendance attendance = Attendance.builder()
+                    .id(ATTENDANCE_ID)
+                    .studentId(STUDENT_ID)
+                    .lessonInstance(lessonInstance)
+                    .build();
+            AcademicPeriod openPeriod = AcademicPeriod.builder().closed(false).build();
+
+            when(attendanceRepository.findWithLessonInstanceById(ATTENDANCE_ID)).thenReturn(Optional.of(attendance));
+            when(academicPeriodService.getByDate(LESSON_DATE)).thenReturn(openPeriod);
+
             service.delete(ATTENDANCE_ID);
 
             verify(attendanceRepository).deleteById(ATTENDANCE_ID);
+        }
+
+        @Test
+        @DisplayName("запись не найдена — бросает NotFoundException")
+        void notFound_throwsException() {
+            when(attendanceRepository.findWithLessonInstanceById(ATTENDANCE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.delete(ATTENDANCE_ID))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessageContaining("Attendance with id: " + ATTENDANCE_ID);
+
+            verify(attendanceRepository, never()).deleteById(any());
+        }
+
+        @Test
+        @DisplayName("академический период закрыт — бросает ConflictException")
+        void closedPeriod_throwsConflictException() {
+            LessonInstance lessonInstance = LessonInstance.builder().id(LESSON_INSTANCE_ID).lessonDate(LESSON_DATE).build();
+            Attendance attendance = Attendance.builder()
+                    .id(ATTENDANCE_ID)
+                    .studentId(STUDENT_ID)
+                    .lessonInstance(lessonInstance)
+                    .build();
+            AcademicPeriod closedPeriod = AcademicPeriod.builder().closed(true).build();
+
+            when(attendanceRepository.findWithLessonInstanceById(ATTENDANCE_ID)).thenReturn(Optional.of(attendance));
+            when(academicPeriodService.getByDate(LESSON_DATE)).thenReturn(closedPeriod);
+
+            assertThatThrownBy(() -> service.delete(ATTENDANCE_ID))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining("is closed");
+
+            verify(attendanceRepository, never()).deleteById(any());
         }
     }
 }

--- a/backend/academic-service/src/test/java/com/rusobr/academic/service/GradeServiceTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/service/GradeServiceTest.java
@@ -119,7 +119,7 @@ class GradeServiceTest {
         @Test
         @DisplayName("успешно создает оценку, если период открыт")
         void success() {
-            CreateGradeRequest request = new CreateGradeRequest(STUDENT_ID, LESSON_ID, 1L, 5, 2, GradeType.TEST);
+            CreateGradeRequest request = new CreateGradeRequest(STUDENT_ID, LESSON_ID, 5, 2, GradeType.TEST);
             LessonInstance lesson = LessonInstance.builder().id(LESSON_ID).lessonDate(DATE).build();
             AcademicPeriod period = AcademicPeriod.builder().closed(false).build();
             Grade grade = new Grade();
@@ -142,7 +142,7 @@ class GradeServiceTest {
         @Test
         @DisplayName("период закрыт — бросает ConflictException")
         void periodClosed_throwsException() {
-            CreateGradeRequest request = new CreateGradeRequest(STUDENT_ID, LESSON_ID, 1L, 5, 2, GradeType.TEST);
+            CreateGradeRequest request = new CreateGradeRequest(STUDENT_ID, LESSON_ID, 5, 2, GradeType.TEST);
             LessonInstance lesson = LessonInstance.builder().lessonDate(DATE).build();
             AcademicPeriod period = AcademicPeriod.builder().closed(true).build();
 

--- a/backend/academic-service/src/test/java/com/rusobr/academic/service/ScheduleServiceTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/service/ScheduleServiceTest.java
@@ -15,12 +15,11 @@ import com.rusobr.academic.infrastructure.persistence.projection.ScheduleLessonP
 import com.rusobr.academic.infrastructure.persistence.projection.SchoolLessonProjection;
 import com.rusobr.academic.infrastructure.persistence.repository.LessonInstanceRepository;
 import com.rusobr.academic.infrastructure.persistence.repository.ScheduleLessonRepository;
+import com.rusobr.academic.web.dto.homework.HomeworkSimpleResponse;
 import com.rusobr.common.dto.BatchUserResponse;
 import com.rusobr.academic.web.dto.attendances.journal.AttendanceSimpleResponse;
 import com.rusobr.common.dto.UserFeignResponse;
 import com.rusobr.academic.web.dto.grade.GradeResponse;
-import com.rusobr.academic.web.dto.homework.HomeworkDiaryResponse;
-import com.rusobr.academic.web.dto.lessonInstance.DiaryLessonInstanceDto;
 import com.rusobr.academic.web.dto.scheduleLesson.*;
 import com.rusobr.academic.web.dto.teachingAssignment.TeachingAssignmentRequest;
 import com.rusobr.common.exception.ConflictException;
@@ -105,7 +104,7 @@ class ScheduleServiceTest {
             AttendanceSimpleResponse att = new AttendanceSimpleResponse(1L, AttendanceStatus.LATE, STUDENT_ID);
             AttendanceSimpleResponse alienAtt = new AttendanceSimpleResponse(2L, AttendanceStatus.ABSENT, 999L);
             GradeResponse grade = new GradeResponse(1L, STUDENT_ID, 5, 1, GradeType.CONTROL);
-            HomeworkDiaryResponse homework = new HomeworkDiaryResponse(1L, "Параграф 5");
+            HomeworkSimpleResponse homework = new HomeworkSimpleResponse(1L, "Параграф 5");
 
             DiaryLessonInstanceDto initialDto = new DiaryLessonInstanceDto(
                     50L, SCHEDULE_ID, DATE,
@@ -119,7 +118,7 @@ class ScheduleServiceTest {
 
             when(scheduleLessonRepository.findDiaryScheduleByStudentId(STUDENT_ID, start, end))
                     .thenReturn(List.of(sl1));
-            when(lessonInstanceRepository.findDiaryAcademicPerformanceByStudentId(List.of(SCHEDULE_ID), start, end, STUDENT_ID))
+            when(lessonInstanceRepository.findLessonInstancesByScheduleId(List.of(SCHEDULE_ID), start, end, STUDENT_ID))
                     .thenReturn(List.of(li1));
             when(lessonInstanceMapper.toDiaryLessonInstance(li1)).thenReturn(initialDto);
 

--- a/backend/user-service/src/main/java/com/rusobr/user/application/service/user/UserOrchestrator.java
+++ b/backend/user-service/src/main/java/com/rusobr/user/application/service/user/UserOrchestrator.java
@@ -40,6 +40,7 @@ public class UserOrchestrator {
             keycloakRestClient.assignRoleToUser(new AssignRoleToUserRequest(kId, kRole.name(), kRole.id()));
 
             userService.setKeycloakId(kId, user.id());
+            log.info("User created: username={} role={}", userCreateRequest.user().username(), userCreateRequest.role());
 
         } catch (Exception e) {
             log.error("Rollback create user: {} keycloakId: {}", user, kId, e);
@@ -76,6 +77,7 @@ public class UserOrchestrator {
             Optional.ofNullable(userUpdateRequest.password())
                     .ifPresent(p -> keycloakRestClient.resetKeycloakPassword(user.getKeycloakId(), p));
 
+            log.info("User updated: userId={}", userId);
             return userResponse;
         } catch (Exception e) {
             log.error("Rollback update user {}", user.getUsername());

--- a/backend/user-service/src/main/java/com/rusobr/user/application/service/user/UserService.java
+++ b/backend/user-service/src/main/java/com/rusobr/user/application/service/user/UserService.java
@@ -79,6 +79,7 @@ public class UserService {
         userRepository.delete(user);
 
         applicationEventPublisher.publishEvent(new UserDeletedEvent(user.getId(), user.getRoles()));
+        log.info("User deleted: userId={}", id);
     }
 
 }

--- a/frontend/src/hooks/use-pdf.ts
+++ b/frontend/src/hooks/use-pdf.ts
@@ -1,101 +1,27 @@
 import { getStudentPeriodFinalReport, getStudentReport, getTeacherReport } from "@/services/pdf-service";
 import { useMutation } from "@tanstack/react-query";
+import { downloadBlob, logDownloadError } from "@/lib/download";
 
 export const useCreateStudentReport = () => {
     return useMutation({
         mutationFn: (periodId: number) => getStudentReport(periodId),
-        onSuccess: (response) => {
-            const blob = response.data;
-            const contentDisposition = response.headers['content-disposition'];
-            let fileName = 'grade-report.pdf';
-
-            if (contentDisposition) {
-                const fileNameMatch = contentDisposition.match(/filename="?([^";]+)"?/);
-                if (fileNameMatch && fileNameMatch[1]) {
-                    fileName = fileNameMatch[1];
-                }
-            }
-
-            const fileURL = window.URL.createObjectURL(blob);
-            const link = document.createElement("a");
-
-            link.href = fileURL;
-            link.setAttribute('download', fileName);
-
-            document.body.appendChild(link);
-            link.click();
-
-            link.parentNode?.removeChild(link);
-            window.URL.revokeObjectURL(fileURL);
-        },
-        onError: (error) => {
-            console.error('Ошибка при генерации PDF:', error);
-        }
+        onSuccess: (response) => downloadBlob(response, 'grade-report.pdf'),
+        onError: logDownloadError,
     });
 };
 
 export const useCreateStudentPeriodFinalReport = () => {
     return useMutation({
         mutationFn: (academicYearId: number) => getStudentPeriodFinalReport(academicYearId),
-        onSuccess: (response) => {
-            const blob = response.data;
-            const contentDisposition = response.headers['content-disposition'];
-            let fileName = 'grade-report.pdf';
-
-            if (contentDisposition) {
-                const fileNameMatch = contentDisposition.match(/filename="?([^";]+)"?/);
-                if (fileNameMatch && fileNameMatch[1]) {
-                    fileName = fileNameMatch[1];
-                }
-            }
-
-            const fileURL = window.URL.createObjectURL(blob);
-            const link = document.createElement("a");
-
-            link.href = fileURL;
-            link.setAttribute('download', fileName);
-
-            document.body.appendChild(link);
-            link.click();
-
-            link.parentNode?.removeChild(link);
-            window.URL.revokeObjectURL(fileURL);
-        },
-        onError: (error) => {
-            console.error('Ошибка при генерации PDF:', error);
-        }
+        onSuccess: (response) => downloadBlob(response, 'grade-report.pdf'),
+        onError: logDownloadError,
     });
 };
 
 export const useCreateTeacherReport = () => {
     return useMutation({
         mutationFn: ({ teachingAssignmentId, periodId }: { teachingAssignmentId: number; periodId: number }) => getTeacherReport({ teachingAssignmentId, periodId }),
-        onSuccess: (response) => {
-            const blob = response.data;
-            const contentDisposition = response.headers['content-disposition'];
-            let fileName = 'grade-report.pdf';
-
-            if (contentDisposition) {
-                const fileNameMatch = contentDisposition.match(/filename="?([^";]+)"?/);
-                if (fileNameMatch && fileNameMatch[1]) {
-                    fileName = fileNameMatch[1];
-                }
-            }
-
-            const fileURL = window.URL.createObjectURL(blob);
-            const link = document.createElement("a");
-
-            link.href = fileURL;
-            link.setAttribute('download', fileName);
-
-            document.body.appendChild(link);
-            link.click();
-
-            link.parentNode?.removeChild(link);
-            window.URL.revokeObjectURL(fileURL);
-        },
-        onError: (error) => {
-            console.error('Ошибка при генерации PDF:', error);
-        }
+        onSuccess: (response) => downloadBlob(response, 'grade-report.pdf'),
+        onError: logDownloadError,
     });
 };

--- a/frontend/src/lib/download.ts
+++ b/frontend/src/lib/download.ts
@@ -1,0 +1,32 @@
+import type { AxiosResponse } from "axios";
+
+type BlobResponse = Pick<AxiosResponse<Blob>, "data" | "headers">;
+
+export function downloadBlob(response: BlobResponse, fallbackName: string) {
+  const blob = response.data;
+  const contentDisposition = response.headers["content-disposition"];
+  let fileName = fallbackName;
+
+  if (contentDisposition) {
+    const fileNameMatch = contentDisposition.match(/filename="?([^";]+)"?/);
+    if (fileNameMatch && fileNameMatch[1]) {
+      fileName = fileNameMatch[1];
+    }
+  }
+
+  const fileURL = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+
+  link.href = fileURL;
+  link.setAttribute("download", fileName);
+
+  document.body.appendChild(link);
+  link.click();
+
+  link.parentNode?.removeChild(link);
+  window.URL.revokeObjectURL(fileURL);
+}
+
+export function logDownloadError(error: unknown) {
+  console.error("Ошибка при генерации PDF:", error);
+}

--- a/frontend/src/services/pdf-service.ts
+++ b/frontend/src/services/pdf-service.ts
@@ -7,7 +7,7 @@ export const getStudentReport = async (periodId: number) => {
 }
 
 export const getStudentPeriodFinalReport = async (academicYearId: number) => {
-    return api.get<Blob>(`/academic-service/api/v1/pdf/student/grade-period-report/report?studentId=27&academicYearId=${academicYearId}`,
+    return api.get<Blob>(`/academic-service/api/v1/pdf/student/grade-period-report/report?academicYearId=${academicYearId}`,
         { responseType: 'blob' }
     );
 }


### PR DESCRIPTION
### Что сделано

### 1. Реализовал проверку прав на мутационные методы в запросах учителя, (IDOR защита)
- Новый `TeacherSecurity` (@PreAuthorize): `canViewAssignment`, `canCreateGrade/canDeleteGrade`, `canCreateAttendance/canDeleteAttendance`, `canCreateHomework/canDeleteHomework`, `canCreatePeriodGrade/canDeletePeriodGrade`, `canCreateFinalGrade/canDeleteFinalGrade`
- Проверки владения через новые SQL-запросы в репозиториях: `isOwnedByTeacher`, `isOwnedByTeacherAndHasStudent`, `isGradeOwnedByTeacher`, `isAttendanceOwnedByTeacher`, `isHomeworkOwnedByTeacher`, `isPeriodGradeOwnedByTeacher`, `isFinalGradeOwnedByTeacher`, `isTeacherOwnedAssignment`, `isOwnedByTeacherWithStudent`
- `gradeSecurity.canViewAssignment` заменён на `teacherSecurity.canViewAssignment` (Grade, Attendance, Homework, FinalGrade, PeriodGrade, Journal, PdfExport контроллеры)
- Проставлены `@ResponseStatus(CREATED/NO_CONTENT)` на мутациях

### 2. Логирование мутаций
- `@Slf4j` + `log.info(...)` на всех мутациях academic-service (periods, years, grades, attendance, homeworks, period/final grades, schedule, classes, subjects, teacher-subjects, class-student) и user-service (create/update/delete user)

### 3. Инвалидация кэшей при мутациях
- Добавлен `schedulesByStudentId` в `@CacheEvict` для grade/attendance/homework
- Добавлен `journalPeriodFinalGradeByStudentId` для period/final grades
- Убран лишний `@Cacheable` на `homeworksByAssignment`

### 4. Фиксы PDF-отчётов
- Починена утечка памяти изза незакрытых потоков загрузки шрифтов (getResourceAsStream) исправил на supplier
- Защита от отсутствующего ученика: `fetchStudentOrThrow` -> 400 `PDF_EXPORT_ERROR`
- `ReportGenerationException` с причиной (cause)
- Общий `downloadBlob` + `logDownloadError` на фронте (`lib/download.ts`), упрощён `use-pdf.ts`

### 5. Security-фиксы
- `AccessDeniedException` -> 403 вместо 500, Общий обработчик неперехваченных `Exception` -> 500 `UNHANDLED_SERVER_ERROR`
- Скрыто внутреннее сообщение БД в `DataIntegrityViolationException` ранее stackTrace уходил в ответ при ошибке
- Валидация `PeriodGradeRequest` (`@NotNull`) и `AttendanceRequest`; убран лишний `academicPeriodId` из `CreateGradeRequest`
- Удаление посещаемости: проверка закрытого академического периода и 404 при отсутствии записи
