### PR TITLE
test: Интеграционные тесты jpa для academic/user сервисов

### DIFF
--- a/backend/academic-service/build.gradle
+++ b/backend/academic-service/build.gradle
@@ -34,8 +34,9 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok:1.18.36'
     annotationProcessor 'org.projectlombok:lombok:1.18.36'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.mockito:mockito-core'
+
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
@@ -50,7 +51,11 @@ dependencies {
     implementation 'com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.10'
     implementation 'com.openhtmltopdf:openhtmltopdf-svg-support:1.0.10'
 
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
 }
 
 tasks.named('test') {

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/AttendanceRepository.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/AttendanceRepository.java
@@ -22,7 +22,7 @@ public interface AttendanceRepository extends JpaRepository<Attendance,Long> {
             join li.scheduleLesson sl
             join sl.teachingAssignment ta
         where ta.teacherId = :teacherId
-        and a.id = :gradeId
+        and a.id = :attendanceId
     """)
     boolean isAttendanceOwnedByTeacher(@Param("teacherId") Long teacherId, @Param("attendanceId") Long attendanceId);
 

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/GradeRepository.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/GradeRepository.java
@@ -20,7 +20,7 @@ public interface GradeRepository extends JpaRepository<Grade, Long> {
     //Запрос берет из schoolClass ученика и сопоставляет оценками и ограничивает данные по teachingAssignmentId
     @Query("""
         select
-            s.id studentId,
+            s.studentId studentId,
             g.id gradeId,
             g.value value,
             g.type type,
@@ -30,9 +30,9 @@ public interface GradeRepository extends JpaRepository<Grade, Long> {
         join li.scheduleLesson sl
         join sl.teachingAssignment ta
         join ta.schoolClass sc
-        join sc.students s on s.id = g.studentId
+        join sc.students s on s.studentId = g.studentId
         where ta.id = :assignmentId
-        order by s.id asc, g.createdAt
+        order by s.studentId asc, g.createdAt
     """)
     List<GradeJournalItemProjection> getClassGrades(@Param("assignmentId") Long assignmentId);
 
@@ -40,7 +40,7 @@ public interface GradeRepository extends JpaRepository<Grade, Long> {
     Optional<Grade> findWithLessonInstanceById(Long id);
 
     @Query("""
-            select coalesce(sum(g.value * g.weight) / sum(g.weight), 0.0)
+            select coalesce(sum(g.value * g.weight * 1.0) / sum(g.weight), 0.0)
             from Grade g
             join g.lessonInstance li
             where g.studentId = :studentId

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/PeriodGradeRepository.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/PeriodGradeRepository.java
@@ -48,8 +48,8 @@ public interface PeriodGradeRepository extends CrudRepository<PeriodGrade, Long>
         from PeriodGrade pg
             join pg.teachingAssignment ta
         where ta.teacherId = :teacherId
-        and pg.id = :gradeId
-""")
+        and pg.id = :periodGradeId
+    """)
     boolean isPeriodGradeOwnedByTeacher(@Param("teacherId") Long teacherId, @Param("periodGradeId") Long periodGradeId);
 
 }

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/SchoolClassRepository.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/persistence/repository/SchoolClassRepository.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 public interface SchoolClassRepository extends JpaRepository<SchoolClass, Long> {
 
     @Query("""
-                select s.id
+                select s.studentId
                 from SchoolClass sc
                 join sc.students s
                 where sc.id = :classId

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/AbstractRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/AbstractRepositoryIT.java
@@ -1,0 +1,41 @@
+package com.rusobr.academic.jpaIT;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class AbstractRepositoryIT {
+
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    static {
+        POSTGRES.start();
+    }
+
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
+    }
+
+    @Autowired
+    protected TestEntityManager em;
+
+    protected <T> T persist(T entity) {
+        return em.persistAndFlush(entity);
+    }
+
+    protected void clearAndFlush() {
+        em.flush();
+        em.clear();
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/AcademicPeriodRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/AcademicPeriodRepositoryIT.java
@@ -1,0 +1,158 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.model.AcademicPeriod;
+import com.rusobr.academic.domain.model.AcademicYear;
+import com.rusobr.academic.infrastructure.persistence.repository.AcademicPeriodRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AcademicPeriodRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    AcademicPeriodRepository academicPeriodRepository;
+
+    @Nested
+    @DisplayName("findByDate")
+    class FindByDate {
+
+        @Test
+        @DisplayName("возвращает период, содержащий дату")
+        void success() {
+            AcademicYear year = persist(TestData.academicYear("2025-2026"));
+            persist(TestData.academicPeriod(year, "1 четверть",
+                    LocalDate.of(2025, 9, 1), LocalDate.of(2025, 10, 31)));
+
+            Optional<AcademicPeriod> period =
+                    academicPeriodRepository.findByDate(LocalDate.of(2025, 10, 15));
+
+            assertThat(period).isPresent();
+            assertThat(period.get().getName()).isEqualTo("1 четверть");
+        }
+
+        @Test
+        @DisplayName("возвращает пусто, если дата вне всех периодов")
+        void returnsEmptyForDateOutsideAllPeriods() {
+            AcademicYear year = persist(TestData.academicYear("2025-2026"));
+            persist(TestData.academicPeriod(year, "1 четверть",
+                    LocalDate.of(2025, 9, 1), LocalDate.of(2025, 10, 31)));
+
+            Optional<AcademicPeriod> period =
+                    academicPeriodRepository.findByDate(LocalDate.of(2025, 8, 1));
+
+            assertThat(period).isNotPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllOrderAsc")
+    class FindAllOrderAsc {
+
+        @Test
+        @DisplayName("загружает учебный год и сортирует периоды по дате начала")
+        void success() {
+            AcademicYear year = persist(TestData.academicYear("2025-2026"));
+            persist(TestData.academicPeriod(year, "2 четверть",
+                    LocalDate.of(2025, 11, 10), LocalDate.of(2025, 12, 26)));
+            persist(TestData.academicPeriod(year, "1 четверть",
+                    LocalDate.of(2025, 9, 1), LocalDate.of(2025, 10, 31)));
+
+            List<AcademicPeriod> periods = academicPeriodRepository.findAllOrderAsc();
+
+            assertThat(periods)
+                    .extracting(AcademicPeriod::getName)
+                    .containsExactly("1 четверть", "2 четверть");
+            assertThat(periods).allSatisfy(p -> assertThat(p.getAcademicYear()).isNotNull());
+        }
+    }
+
+    @Nested
+    @DisplayName("findWithAcademicYearById")
+    class FindWithAcademicYearById {
+
+        @Test
+        @DisplayName("загружает учебный год периода")
+        void success() {
+            AcademicYear year = persist(TestData.academicYear("2025-2026"));
+            AcademicPeriod period = persist(TestData.academicPeriod(year, "1 четверть",
+                    LocalDate.of(2025, 9, 1), LocalDate.of(2025, 10, 31)));
+            clearAndFlush();
+
+            Optional<AcademicPeriod> found = academicPeriodRepository.findWithAcademicYearById(period.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getAcademicYear().getName()).isEqualTo("2025-2026");
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByAcademicYearIdOrderByStartDateAsc")
+    class FindAllByAcademicYearIdOrderByStartDateAsc {
+
+        @Test
+        @DisplayName("возвращает только периоды указанного года в порядке возрастания")
+        void success() {
+            AcademicYear year = persist(TestData.academicYear("2025-2026"));
+            AcademicYear other = persist(AcademicYear.builder()
+                    .name("2024-2025")
+                    .startDate(LocalDate.of(2024, 9, 1))
+                    .endDate(LocalDate.of(2025, 5, 31))
+                    .build());
+            persist(TestData.academicPeriod(year, "2 четверть",
+                    LocalDate.of(2025, 11, 10), LocalDate.of(2025, 12, 26)));
+            persist(TestData.academicPeriod(year, "1 четверть",
+                    LocalDate.of(2025, 9, 1), LocalDate.of(2025, 10, 31)));
+            persist(TestData.academicPeriod(other, "1 четверть",
+                    LocalDate.of(2024, 9, 1), LocalDate.of(2024, 10, 31)));
+
+            List<AcademicPeriod> periods = academicPeriodRepository
+                    .findAllByAcademicYearIdOrderByStartDateAsc(year.getId());
+
+            assertThat(periods).extracting(AcademicPeriod::getName)
+                    .containsExactly("1 четверть", "2 четверть");
+        }
+    }
+
+    @Nested
+    @DisplayName("getAcademicPeriodsByAcademicYearId")
+    class GetAcademicPeriodsByAcademicYearId {
+
+        @Test
+        @DisplayName("возвращает периоды учебного года")
+        void success() {
+            AcademicYear year = persist(TestData.academicYear("2025-2026"));
+            persist(TestData.academicPeriod(year, "1 четверть",
+                    LocalDate.of(2025, 9, 1), LocalDate.of(2025, 10, 31)));
+
+            List<AcademicPeriod> periods = academicPeriodRepository
+                    .getAcademicPeriodsByAcademicYearId(year.getId());
+
+            assertThat(periods).hasSize(1);
+            assertThat(periods.get(0).getName()).isEqualTo("1 четверть");
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByName")
+    class ExistsByName {
+
+        @Test
+        @DisplayName("проверяет наличие периода с указанным именем")
+        void success() {
+            AcademicYear year = persist(TestData.academicYear("2025-2026"));
+            persist(TestData.academicPeriod(year, "1 четверть",
+                    LocalDate.of(2025, 9, 1), LocalDate.of(2025, 10, 31)));
+
+            assertThat(academicPeriodRepository.existsByName("1 четверть")).isTrue();
+            assertThat(academicPeriodRepository.existsByName("3 четверть")).isFalse();
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/AcademicYearRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/AcademicYearRepositoryIT.java
@@ -1,0 +1,46 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.model.AcademicYear;
+import com.rusobr.academic.infrastructure.persistence.repository.AcademicYearRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AcademicYearRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    AcademicYearRepository academicYearRepository;
+
+    @Nested
+    @DisplayName("findAllByOrderByStartDateDesc")
+    class FindAllByOrderByStartDateDesc {
+
+        @Test
+        @DisplayName("возвращает учебные годы от новых к старым")
+        void success() {
+            AcademicYear older = persist(AcademicYear.builder()
+                    .name("2024-2025")
+                    .startDate(LocalDate.of(2024, 9, 1))
+                    .endDate(LocalDate.of(2025, 5, 31))
+                    .build());
+            persist(AcademicYear.builder()
+                    .name("2025-2026")
+                    .startDate(LocalDate.of(2025, 9, 1))
+                    .endDate(LocalDate.of(2026, 5, 31))
+                    .build());
+
+            List<AcademicYear> years = academicYearRepository.findAllByOrderByStartDateDesc();
+
+            assertThat(years).extracting(AcademicYear::getName)
+                    .containsExactly("2025-2026", "2024-2025");
+            assertThat(years.get(1).getId()).isEqualTo(older.getId());
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/AttendanceRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/AttendanceRepositoryIT.java
@@ -1,0 +1,105 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.enums.AttendanceStatus;
+import com.rusobr.academic.domain.model.Attendance;
+import com.rusobr.academic.domain.model.LessonInstance;
+import com.rusobr.academic.domain.model.ScheduleLesson;
+import com.rusobr.academic.domain.model.SchoolClass;
+import com.rusobr.academic.domain.model.Subject;
+import com.rusobr.academic.domain.model.TeachingAssignment;
+import com.rusobr.academic.infrastructure.persistence.repository.AttendanceRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AttendanceRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    AttendanceRepository attendanceRepository;
+
+    private static final long STUDENT_ID = 11L;
+    private static final long TEACHER_ID = 7L;
+
+    private LessonInstance lessonInstance;
+    private Attendance attendance;
+
+    private void setUpGraph() {
+        var year = persist(TestData.academicYear("2025-2026"));
+        SchoolClass schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+        persist(TestData.classStudent(schoolClass, STUDENT_ID));
+        Subject subject = persist(TestData.subject("Математика"));
+        TeachingAssignment assignment = persist(TestData.assignment(TEACHER_ID, schoolClass, subject));
+        ScheduleLesson scheduleLesson = persist(TestData.scheduleLesson(assignment, DayOfWeek.MONDAY, 1));
+        lessonInstance = persist(TestData.lessonInstance(scheduleLesson, LocalDate.of(2025, 9, 15)));
+        attendance = persist(TestData.attendance(STUDENT_ID, lessonInstance, AttendanceStatus.ABSENT));
+    }
+
+    @Nested
+    @DisplayName("findByStudentIdAndLessonInstanceId")
+    class FindByStudentIdAndLessonInstanceId {
+
+        @Test
+        @DisplayName("находит посещаемость ученика на уроке")
+        void success() {
+            setUpGraph();
+
+            Optional<Attendance> found = attendanceRepository
+                    .findByStudentIdAndLessonInstanceId(STUDENT_ID, lessonInstance.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getStatus()).isEqualTo(AttendanceStatus.ABSENT);
+        }
+
+        @Test
+        @DisplayName("возвращает пусто, если посещаемость отсутствует")
+        void returnsEmptyWhenAbsent() {
+            setUpGraph();
+
+            assertThat(attendanceRepository
+                    .findByStudentIdAndLessonInstanceId(999L, lessonInstance.getId())).isNotPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("isAttendanceOwnedByTeacher")
+    class IsAttendanceOwnedByTeacher {
+
+        @Test
+        @DisplayName("возвращает true для учителя предмета и false для другого")
+        void success() {
+            setUpGraph();
+
+            assertThat(attendanceRepository
+                    .isAttendanceOwnedByTeacher(TEACHER_ID, attendance.getId())).isTrue();
+            assertThat(attendanceRepository
+                    .isAttendanceOwnedByTeacher(99L, attendance.getId())).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findWithLessonInstanceById")
+    class FindWithLessonInstanceById {
+
+        @Test
+        @DisplayName("загружает урок посещаемости")
+        void success() {
+            setUpGraph();
+            clearAndFlush();
+
+            Optional<Attendance> found = attendanceRepository.findWithLessonInstanceById(attendance.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getLessonInstance()).isNotNull();
+            assertThat(found.get().getLessonInstance().getLessonDate())
+                    .isEqualTo(LocalDate.of(2025, 9, 15));
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/ClassStudentRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/ClassStudentRepositoryIT.java
@@ -1,0 +1,77 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.model.ClassStudent;
+import com.rusobr.academic.infrastructure.persistence.repository.ClassStudentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassStudentRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    ClassStudentRepository classStudentRepository;
+
+    @Nested
+    @DisplayName("existsByStudentId")
+    class ExistsByStudentId {
+
+        @Test
+        @DisplayName("возвращает true, если ученик состоит в классе")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            persist(TestData.classStudent(schoolClass, 11L));
+
+            assertThat(classStudentRepository.existsByStudentId(11L)).isTrue();
+            assertThat(classStudentRepository.existsByStudentId(99L)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findBySchoolClassIdAndStudentId")
+    class FindBySchoolClassIdAndStudentId {
+
+        @Test
+        @DisplayName("находит запись ученика в классе")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            persist(TestData.classStudent(schoolClass, 11L));
+
+            Optional<ClassStudent> found = classStudentRepository
+                    .findBySchoolClassIdAndStudentId(schoolClass.getId(), 11L);
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getSchoolClass().getId()).isEqualTo(schoolClass.getId());
+            assertThat(classStudentRepository
+                    .findBySchoolClassIdAndStudentId(schoolClass.getId(), 12L)).isNotPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllStudentIds")
+    class FindAllStudentIds {
+
+        @Test
+        @DisplayName("собирает id всех учеников по классам")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var classA = persist(TestData.schoolClass(year, "5А", 42L));
+            var classB = persist(TestData.schoolClass(year, "5Б", 43L));
+            persist(TestData.classStudent(classA, 11L));
+            persist(TestData.classStudent(classA, 12L));
+            persist(TestData.classStudent(classB, 13L));
+
+            Set<Long> ids = classStudentRepository.findAllStudentIds();
+
+            assertThat(ids).containsExactlyInAnyOrder(11L, 12L, 13L);
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/FinalGradeRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/FinalGradeRepositoryIT.java
@@ -1,0 +1,121 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.model.AcademicYear;
+import com.rusobr.academic.domain.model.FinalGrade;
+import com.rusobr.academic.domain.model.SchoolClass;
+import com.rusobr.academic.domain.model.Subject;
+import com.rusobr.academic.domain.model.TeachingAssignment;
+import com.rusobr.academic.infrastructure.persistence.repository.FinalGradeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FinalGradeRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    FinalGradeRepository finalGradeRepository;
+
+    private static final long STUDENT_ID = 11L;
+    private static final long TEACHER_ID = 7L;
+
+    private AcademicYear year;
+    private AcademicYear previousYear;
+    private TeachingAssignment assignment;
+    private TeachingAssignment biologyAssignment;
+
+    private void setUpGraph() {
+        year = persist(TestData.academicYear("2025-2026"));
+        previousYear = persist(AcademicYear.builder()
+                .name("2024-2025")
+                .startDate(LocalDate.of(2024, 9, 1))
+                .endDate(LocalDate.of(2025, 5, 31))
+                .build());
+        SchoolClass schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+        Subject math = persist(TestData.subject("Математика"));
+        Subject biology = persist(TestData.subject("Биология"));
+        assignment = persist(TestData.assignment(TEACHER_ID, schoolClass, math));
+        biologyAssignment = persist(TestData.assignment(TEACHER_ID, schoolClass, biology));
+    }
+
+    @Nested
+    @DisplayName("findFinalGradesByStudentId")
+    class FindFinalGradesByStudentId {
+
+        @Test
+        @DisplayName("возвращает итоговые оценки ученика за год, отсортированные по предмету")
+        void success() {
+            setUpGraph();
+            persist(TestData.finalGrade(STUDENT_ID, year, assignment, 5));
+            persist(TestData.finalGrade(STUDENT_ID, year, biologyAssignment, 3));
+            persist(TestData.finalGrade(STUDENT_ID, previousYear, assignment, 4));
+
+            List<FinalGrade> grades = finalGradeRepository
+                    .findFinalGradesByStudentId(STUDENT_ID, year.getId());
+
+            assertThat(grades).hasSize(2);
+            assertThat(grades).extracting(FinalGrade::getValue).containsExactly(3, 5);
+            assertThat(grades.get(0).getTeachingAssignment().getSubject().getName()).isEqualTo("Биология");
+            assertThat(grades.get(0).getAcademicYear().getName()).isEqualTo("2025-2026");
+        }
+    }
+
+    @Nested
+    @DisplayName("findFinalGradesByTeachingAssignmentId")
+    class FindFinalGradesByTeachingAssignmentId {
+
+        @Test
+        @DisplayName("возвращает оценки по назначению за указанный год")
+        void success() {
+            setUpGraph();
+            persist(TestData.finalGrade(STUDENT_ID, year, assignment, 5));
+            persist(TestData.finalGrade(STUDENT_ID, previousYear, assignment, 4));
+
+            List<FinalGrade> grades = finalGradeRepository
+                    .findFinalGradesByTeachingAssignmentId(assignment.getId(), year.getId());
+
+            assertThat(grades).hasSize(1);
+            assertThat(grades.get(0).getValue()).isEqualTo(5);
+        }
+    }
+
+    @Nested
+    @DisplayName("findWithAcademicYearById")
+    class FindWithAcademicYearById {
+
+        @Test
+        @DisplayName("загружает учебный год оценки")
+        void success() {
+            setUpGraph();
+            FinalGrade grade = persist(TestData.finalGrade(STUDENT_ID, year, assignment, 5));
+            clearAndFlush();
+
+            Optional<FinalGrade> found = finalGradeRepository.findWithAcademicYearById(grade.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getAcademicYear().getName()).isEqualTo("2025-2026");
+        }
+    }
+
+    @Nested
+    @DisplayName("isFinalGradeOwnedByTeacher")
+    class IsFinalGradeOwnedByTeacher {
+
+        @Test
+        @DisplayName("возвращает true для учителя предмета и false для другого")
+        void success() {
+            setUpGraph();
+            FinalGrade grade = persist(TestData.finalGrade(STUDENT_ID, year, assignment, 5));
+
+            assertThat(finalGradeRepository.isFinalGradeOwnedByTeacher(TEACHER_ID, grade.getId())).isTrue();
+            assertThat(finalGradeRepository.isFinalGradeOwnedByTeacher(99L, grade.getId())).isFalse();
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/GradeRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/GradeRepositoryIT.java
@@ -1,0 +1,218 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.enums.GradeType;
+import com.rusobr.academic.domain.model.Grade;
+import com.rusobr.academic.domain.model.LessonInstance;
+import com.rusobr.academic.domain.model.ScheduleLesson;
+import com.rusobr.academic.domain.model.SchoolClass;
+import com.rusobr.academic.domain.model.Subject;
+import com.rusobr.academic.domain.model.TeachingAssignment;
+import com.rusobr.academic.infrastructure.persistence.projection.GradeDetailProjection;
+import com.rusobr.academic.infrastructure.persistence.projection.GradeJournalItemProjection;
+import com.rusobr.academic.infrastructure.persistence.projection.GradeWithSubjectNameProjection;
+import com.rusobr.academic.infrastructure.persistence.projection.StudentAverageProjection;
+import com.rusobr.academic.infrastructure.persistence.repository.GradeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GradeRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    GradeRepository gradeRepository;
+
+    private static final long STUDENT_1 = 11L;
+    private static final long STUDENT_2 = 12L;
+    private static final long TEACHER_ID = 7L;
+
+    private static final LocalDate D1 = LocalDate.of(2025, 9, 15);
+    private static final LocalDate D2 = LocalDate.of(2025, 9, 16);
+
+    private TeachingAssignment assignment;
+    private LessonInstance firstInstance;
+    private LessonInstance secondInstance;
+    private Grade studentOneFirst;
+    private Grade studentTwoFirst;
+
+    private void setUpGraph() {
+        var year = persist(TestData.academicYear("2025-2026"));
+        SchoolClass schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+        persist(TestData.classStudent(schoolClass, STUDENT_1));
+        persist(TestData.classStudent(schoolClass, STUDENT_2));
+        Subject subject = persist(TestData.subject("Математика"));
+        assignment = persist(TestData.assignment(TEACHER_ID, schoolClass, subject));
+
+        ScheduleLesson scheduleLesson = persist(TestData.scheduleLesson(assignment, DayOfWeek.MONDAY, 1));
+        firstInstance = persist(TestData.lessonInstance(scheduleLesson, D1));
+        secondInstance = persist(TestData.lessonInstance(scheduleLesson, D2));
+
+        studentOneFirst = persist(TestData.grade(STUDENT_1, firstInstance, 4, 2, GradeType.CONTROL));
+        persist(TestData.grade(STUDENT_1, secondInstance, 2, 1, GradeType.HOMEWORK));
+        studentTwoFirst = persist(TestData.grade(STUDENT_2, firstInstance, 5, 1, GradeType.TEST));
+    }
+
+    @Nested
+    @DisplayName("getClassGrades")
+    class GetClassGrades {
+
+        @Test
+        @DisplayName("возвращает оценки назначения, отсортированные по ученику")
+        void success() {
+            setUpGraph();
+
+            List<GradeJournalItemProjection> grades = gradeRepository.getClassGrades(assignment.getId());
+
+            assertThat(grades).hasSize(3);
+            assertThat(grades).extracting(GradeJournalItemProjection::getStudentId)
+                    .containsExactly(STUDENT_1, STUDENT_1, STUDENT_2);
+            assertThat(grades).extracting(GradeJournalItemProjection::getValue)
+                    .containsExactlyInAnyOrder(4, 2, 5);
+            assertThat(grades).extracting(GradeJournalItemProjection::getLessonDate)
+                    .contains(D1, D2);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAverageGrade")
+    class GetAverageGrade {
+
+        @Test
+        @DisplayName("вычисляет средневзвешенный балл")
+        void success() {
+            setUpGraph();
+
+            Double average = gradeRepository.getAverageGrade(STUDENT_1, D1, D2);
+
+            assertThat(average).isCloseTo(3.3333, org.assertj.core.data.Offset.offset(0.001));
+        }
+
+        @Test
+        @DisplayName("возвращает 0, если оценок в диапазоне нет")
+        void returnsZeroWhenNoGradesInRange() {
+            setUpGraph();
+
+            Double average = gradeRepository.getAverageGrade(STUDENT_1,
+                    LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31));
+
+            assertThat(average).isEqualTo(0.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByDateAndStudentId")
+    class FindAllByDateAndStudentId {
+
+        @Test
+        @DisplayName("возвращает оценки ученика за дату с названием предмета")
+        void success() {
+            setUpGraph();
+
+            List<GradeWithSubjectNameProjection> grades =
+                    gradeRepository.findAllByDateAndStudentId(STUDENT_1, D1);
+
+            assertThat(grades).hasSize(1);
+            assertThat(grades.get(0).getSubjectName()).isEqualTo("Математика");
+            assertThat(grades.get(0).getValue()).isEqualTo(4);
+            assertThat(grades.get(0).getGradeType()).isEqualTo(GradeType.CONTROL);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAverageStudentsByTeachingAssignment")
+    class FindAverageStudentsByTeachingAssignment {
+
+        @Test
+        @DisplayName("группирует средний балл по ученикам")
+        void success() {
+            setUpGraph();
+
+            List<StudentAverageProjection> averages = gradeRepository
+                    .findAverageStudentsByTeachingAssignment(assignment.getId(), D1, D2);
+
+            assertThat(averages).hasSize(2);
+            StudentAverageProjection studentOne = averages.stream()
+                    .filter(a -> a.getStudentId().equals(STUDENT_1))
+                    .findFirst().orElseThrow();
+            StudentAverageProjection studentTwo = averages.stream()
+                    .filter(a -> a.getStudentId().equals(STUDENT_2))
+                    .findFirst().orElseThrow();
+            assertThat(studentOne.getAverage()).isCloseTo(3.33, org.assertj.core.data.Offset.offset(0.01));
+            assertThat(studentTwo.getAverage()).isEqualTo(5.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("findDetailById")
+    class FindDetailById {
+
+        @Test
+        @DisplayName("возвращает детали оценки с учителем")
+        void success() {
+            setUpGraph();
+
+            Optional<GradeDetailProjection> detail = gradeRepository.findDetailById(studentOneFirst.getId());
+
+            assertThat(detail).isPresent();
+            assertThat(detail.get().getValue()).isEqualTo(4);
+            assertThat(detail.get().getWeight()).isEqualTo(2);
+            assertThat(detail.get().getGradeType()).isEqualTo(GradeType.CONTROL);
+            assertThat(detail.get().getTeacherId()).isEqualTo(TEACHER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByIdAndStudentId")
+    class ExistsByIdAndStudentId {
+
+        @Test
+        @DisplayName("проверяет принадлежность оценки ученику")
+        void success() {
+            setUpGraph();
+
+            assertThat(gradeRepository.existsByIdAndStudentId(studentOneFirst.getId(), STUDENT_1)).isTrue();
+            assertThat(gradeRepository.existsByIdAndStudentId(studentOneFirst.getId(), STUDENT_2)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isGradeOwnedByTeacher")
+    class IsGradeOwnedByTeacher {
+
+        @Test
+        @DisplayName("возвращает true для учителя предмета и false для другого")
+        void success() {
+            setUpGraph();
+
+            assertThat(gradeRepository.isGradeOwnedByTeacher(TEACHER_ID, studentOneFirst.getId())).isTrue();
+            assertThat(gradeRepository.isGradeOwnedByTeacher(99L, studentOneFirst.getId())).isFalse();
+            assertThat(gradeRepository.isGradeOwnedByTeacher(TEACHER_ID, studentTwoFirst.getId())).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("findWithLessonInstanceById")
+    class FindWithLessonInstanceById {
+
+        @Test
+        @DisplayName("загружает урок оценки")
+        void success() {
+            setUpGraph();
+            clearAndFlush();
+
+            Optional<Grade> found = gradeRepository.findWithLessonInstanceById(studentOneFirst.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getLessonInstance()).isNotNull();
+            assertThat(found.get().getLessonInstance().getLessonDate()).isEqualTo(D1);
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/HomeworkRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/HomeworkRepositoryIT.java
@@ -1,0 +1,128 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.model.Homework;
+import com.rusobr.academic.domain.model.LessonInstance;
+import com.rusobr.academic.domain.model.ScheduleLesson;
+import com.rusobr.academic.domain.model.SchoolClass;
+import com.rusobr.academic.domain.model.Subject;
+import com.rusobr.academic.domain.model.TeachingAssignment;
+import com.rusobr.academic.infrastructure.persistence.projection.HomeworkWithSubjectProjection;
+import com.rusobr.academic.infrastructure.persistence.repository.HomeworkRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HomeworkRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    HomeworkRepository homeworkRepository;
+
+    private static final long STUDENT_ID = 11L;
+    private static final long TEACHER_ID = 7L;
+
+    private TeachingAssignment assignment;
+    private LessonInstance lessonInstance;
+    private Homework homework;
+
+    private void setUpGraph() {
+        var year = persist(TestData.academicYear("2025-2026"));
+        SchoolClass schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+        persist(TestData.classStudent(schoolClass, STUDENT_ID));
+        Subject subject = persist(TestData.subject("Математика"));
+        assignment = persist(TestData.assignment(TEACHER_ID, schoolClass, subject));
+        ScheduleLesson scheduleLesson = persist(TestData.scheduleLesson(assignment, DayOfWeek.MONDAY, 1));
+        lessonInstance = persist(TestData.lessonInstance(scheduleLesson, LocalDate.of(2025, 9, 15)));
+        homework = persist(TestData.homework(lessonInstance, "Параграф 5, упражнения 1-3"));
+    }
+
+    @Nested
+    @DisplayName("findHomeworksByDate")
+    class FindHomeworksByDate {
+
+        @Test
+        @DisplayName("возвращает домашние задания ученика за дату")
+        void success() {
+            setUpGraph();
+
+            List<HomeworkWithSubjectProjection> homeworks = homeworkRepository
+                    .findHomeworksByDate(LocalDate.of(2025, 9, 15), STUDENT_ID);
+
+            assertThat(homeworks).hasSize(1);
+            assertThat(homeworks.get(0).getText()).isEqualTo("Параграф 5, упражнения 1-3");
+            assertThat(homeworks.get(0).getSubjectName()).isEqualTo("Математика");
+        }
+
+        @Test
+        @DisplayName("возвращает пусто для другой даты или ученика")
+        void returnsEmptyForOtherDateOrStudent() {
+            setUpGraph();
+
+            assertThat(homeworkRepository
+                    .findHomeworksByDate(LocalDate.of(2025, 9, 16), STUDENT_ID)).isEmpty();
+            assertThat(homeworkRepository
+                    .findHomeworksByDate(LocalDate.of(2025, 9, 15), 999L)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findHomeworksByTeachingAssignmentId")
+    class FindHomeworksByTeachingAssignmentId {
+
+        @Test
+        @DisplayName("возвращает домашние задания назначения постранично")
+        void success() {
+            setUpGraph();
+
+            Page<Homework> page = homeworkRepository
+                    .findHomeworksByTeachingAssignmentId(assignment.getId(), PageRequest.of(0, 10));
+
+            assertThat(page.getTotalElements()).isEqualTo(1);
+            assertThat(page.getContent()).extracting(Homework::getText)
+                    .containsExactly("Параграф 5, упражнения 1-3");
+        }
+    }
+
+    @Nested
+    @DisplayName("findWithLessonInstanceById")
+    class FindWithLessonInstanceById {
+
+        @Test
+        @DisplayName("загружает урок домашнего задания")
+        void success() {
+            setUpGraph();
+            clearAndFlush();
+
+            Optional<Homework> found = homeworkRepository.findWithLessonInstanceById(homework.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getLessonInstance()).isNotNull();
+            assertThat(found.get().getLessonInstance().getLessonDate())
+                    .isEqualTo(LocalDate.of(2025, 9, 15));
+        }
+    }
+
+    @Nested
+    @DisplayName("isHomeworkOwnedByTeacher")
+    class IsHomeworkOwnedByTeacher {
+
+        @Test
+        @DisplayName("возвращает true для учителя предмета и false для другого")
+        void success() {
+            setUpGraph();
+
+            assertThat(homeworkRepository.isHomeworkOwnedByTeacher(TEACHER_ID, homework.getId())).isTrue();
+            assertThat(homeworkRepository.isHomeworkOwnedByTeacher(99L, homework.getId())).isFalse();
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/LessonInstanceRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/LessonInstanceRepositoryIT.java
@@ -1,0 +1,333 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.enums.AttendanceStatus;
+import com.rusobr.academic.domain.enums.GradeType;
+import com.rusobr.academic.domain.model.Grade;
+import com.rusobr.academic.domain.model.LessonInstance;
+import com.rusobr.academic.domain.model.ScheduleLesson;
+import com.rusobr.academic.domain.model.SchoolClass;
+import com.rusobr.academic.domain.model.Subject;
+import com.rusobr.academic.domain.model.TeachingAssignment;
+import com.rusobr.academic.infrastructure.persistence.projection.AttendanceStudentProjection;
+import com.rusobr.academic.infrastructure.persistence.projection.GradeJournalProjection;
+import com.rusobr.academic.infrastructure.persistence.projection.GradeStudentProjection;
+import com.rusobr.academic.infrastructure.persistence.projection.LessonInstanceProjection;
+import com.rusobr.academic.infrastructure.persistence.repository.LessonInstanceRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LessonInstanceRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    LessonInstanceRepository lessonInstanceRepository;
+
+    private static final long STUDENT_1 = 11L;
+    private static final long STUDENT_2 = 12L;
+    private static final long TEACHER_ID = 7L;
+
+    private static final LocalDate D1 = LocalDate.of(2025, 9, 15);
+    private static final LocalDate D2 = LocalDate.of(2025, 9, 16);
+    private static final LocalDate D3 = LocalDate.of(2025, 9, 22);
+
+    private TeachingAssignment assignment;
+    private ScheduleLesson mondayLesson;
+    private ScheduleLesson tuesdayLesson;
+    private LessonInstance mondayInstance;
+    private LessonInstance tuesdayInstance;
+
+    private void setUpGraph() {
+        var year = persist(TestData.academicYear("2025-2026"));
+        SchoolClass schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+        persist(TestData.classStudent(schoolClass, STUDENT_1));
+        persist(TestData.classStudent(schoolClass, STUDENT_2));
+        Subject subject = persist(TestData.subject("Математика"));
+        assignment = persist(TestData.assignment(TEACHER_ID, schoolClass, subject));
+
+        mondayLesson = persist(TestData.scheduleLesson(assignment, DayOfWeek.MONDAY, 1));
+        tuesdayLesson = persist(TestData.scheduleLesson(assignment, DayOfWeek.TUESDAY, 2));
+
+        mondayInstance = persist(TestData.lessonInstance(mondayLesson, D1));
+        tuesdayInstance = persist(TestData.lessonInstance(tuesdayLesson, D2));
+        persist(TestData.lessonInstance(mondayLesson, D3));
+
+        persist(TestData.grade(STUDENT_1, mondayInstance, 4, 2, GradeType.CONTROL));
+        persist(TestData.attendance(STUDENT_1, mondayInstance, AttendanceStatus.ABSENT));
+        persist(TestData.homework(mondayInstance, "Параграф 5"));
+    }
+
+    @Nested
+    @DisplayName("findDiaryLessonsByStudentIdAndDateRange")
+    class FindDiaryLessonsByStudentIdAndDateRange {
+
+        @Test
+        @DisplayName("возвращает уроки ученика за диапазон дат с оценками")
+        void success() {
+            setUpGraph();
+            clearAndFlush();
+
+            List<LessonInstance> lessons = lessonInstanceRepository
+                    .findDiaryLessonsByStudentIdAndDateRange(STUDENT_1, D1, D3);
+
+            assertThat(lessons).extracting(LessonInstance::getLessonDate)
+                    .containsExactly(D1, D2, D3);
+            LessonInstance first = lessons.stream()
+                    .filter(li -> li.getLessonDate().equals(D1))
+                    .findFirst().orElseThrow();
+            assertThat(first.getGrades())
+                    .extracting(Grade::getValue)
+                    .containsExactly(4);
+        }
+    }
+
+    @Nested
+    @DisplayName("findGradesLessonsByStudentId")
+    class FindGradesLessonsByStudentId {
+
+        @Test
+        @DisplayName("возвращает журнал оценок ученика")
+        void success() {
+            setUpGraph();
+            persist(TestData.grade(STUDENT_1, tuesdayInstance, 5, 1, GradeType.TEST));
+
+            List<GradeJournalProjection> journal = lessonInstanceRepository
+                    .findGradesLessonsByStudentId(STUDENT_1, D1, D2);
+
+            assertThat(journal)
+                    .extracting(GradeJournalProjection::getLessonDate)
+                    .containsExactly(D1, D2);
+            assertThat(journal)
+                    .extracting(GradeJournalProjection::getSubjectName)
+                    .containsOnly("Математика");
+            assertThat(journal)
+                    .extracting(GradeJournalProjection::getValue)
+                    .containsExactly(4, 5);
+        }
+    }
+
+    @Nested
+    @DisplayName("findLessonDatesByStudentId")
+    class FindLessonDatesByStudentId {
+
+        @Test
+        @DisplayName("возвращает уникальные даты уроков ученика")
+        void success() {
+            setUpGraph();
+
+            List<LocalDate> dates = lessonInstanceRepository
+                    .findLessonDatesByStudentId(STUDENT_1, D1, D3);
+
+            assertThat(dates).containsExactly(D1, D2, D3);
+        }
+    }
+
+    @Nested
+    @DisplayName("findLessonInstanceByTeachingAssignmentId")
+    class FindLessonInstanceByTeachingAssignmentId {
+
+        @Test
+        @DisplayName("возвращает проекции уроков назначения")
+        void success() {
+            setUpGraph();
+
+            List<LessonInstanceProjection> lessons = lessonInstanceRepository
+                    .findLessonInstanceByTeachingAssignmentId(assignment.getId(), D1, D3);
+
+            assertThat(lessons).hasSize(3);
+            assertThat(lessons)
+                    .extracting(LessonInstanceProjection::getLessonDate)
+                    .containsExactly(D1, D2, D3);
+        }
+    }
+
+    @Nested
+    @DisplayName("findGradesByTeachingAssignment")
+    class FindGradesByTeachingAssignment {
+
+        @Test
+        @DisplayName("возвращает оценки по назначению")
+        void success() {
+            setUpGraph();
+
+            List<GradeStudentProjection> grades = lessonInstanceRepository
+                    .findGradesByTeachingAssignment(assignment.getId(), D1, D3);
+
+            assertThat(grades).hasSize(1);
+            assertThat(grades.get(0).getStudentId()).isEqualTo(STUDENT_1);
+            assertThat(grades.get(0).getValue()).isEqualTo(4);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAttendancesByTeachingAssignment")
+    class FindAttendancesByTeachingAssignment {
+
+        @Test
+        @DisplayName("возвращает посещаемость по назначению")
+        void success() {
+            setUpGraph();
+
+            List<AttendanceStudentProjection> attendances = lessonInstanceRepository
+                    .findAttendancesByTeachingAssignment(assignment.getId(), D1, D3);
+
+            assertThat(attendances).hasSize(1);
+            assertThat(attendances.get(0).getStudentId()).isEqualTo(STUDENT_1);
+            assertThat(attendances.get(0).getStatus()).isEqualTo(AttendanceStatus.ABSENT);
+        }
+    }
+
+    @Nested
+    @DisplayName("softDeleteFutureEmptyAfterDate")
+    class SoftDeleteFutureEmptyAfterDate {
+
+        @Test
+        @DisplayName("удаляет только пустые будущие уроки")
+        void success() {
+            setUpGraph();
+            LessonInstance futureEmpty = persist(TestData.lessonInstance(mondayLesson, D3.plusWeeks(1)));
+            LessonInstance futureWithGrade = persist(TestData.lessonInstance(mondayLesson, D3.plusWeeks(2)));
+            persist(TestData.grade(STUDENT_1, futureWithGrade, 5, 1, GradeType.TEST));
+
+            lessonInstanceRepository.softDeleteFutureEmptyAfterDate(mondayLesson.getId(), D3);
+            clearAndFlush();
+
+            assertThat(lessonInstanceRepository.findById(futureEmpty.getId())).isNotPresent();
+            assertThat(lessonInstanceRepository.findById(futureWithGrade.getId())).isPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByScheduleLessonAndLessonDate")
+    class ExistsByScheduleLessonAndLessonDate {
+
+        @Test
+        @DisplayName("проверяет уникальность урока на дату")
+        void success() {
+            setUpGraph();
+
+            assertThat(lessonInstanceRepository
+                    .existsByScheduleLessonAndLessonDate(mondayLesson, D1)).isTrue();
+            assertThat(lessonInstanceRepository
+                    .existsByScheduleLessonAndLessonDate(mondayLesson, LocalDate.of(2025, 9, 30))).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findLessonInstancesByScheduleId")
+    class FindLessonInstancesByScheduleId {
+
+        @Test
+        @DisplayName("возвращает уроки по идентификаторам расписаний")
+        void success() {
+            setUpGraph();
+
+            List<LessonInstance> lessons = lessonInstanceRepository
+                    .findLessonInstancesByScheduleId(List.of(mondayLesson.getId(), tuesdayLesson.getId()), D1, D3);
+
+            assertThat(lessons).hasSize(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("findLessonInstanceGradesByPeriodAndStudent")
+    class FindLessonInstanceGradesByPeriodAndStudent {
+
+        @Test
+        @DisplayName("возвращает уроки с оценками только для указанного ученика")
+        void success() {
+            setUpGraph();
+            persist(TestData.grade(STUDENT_2, tuesdayInstance, 3, 1, GradeType.HOMEWORK));
+
+            List<LessonInstance> lessons = lessonInstanceRepository
+                    .findLessonInstanceGradesByPeriodAndStudent(
+                            List.of(mondayLesson.getId(), tuesdayLesson.getId()), D1, D2, STUDENT_1);
+
+            assertThat(lessons).extracting(LessonInstance::getId)
+                    .containsExactly(mondayInstance.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("findLessonInstanceAttendancesByPeriodAndStudent")
+    class FindLessonInstanceAttendancesByPeriodAndStudent {
+
+        @Test
+        @DisplayName("возвращает уроки с посещаемостью только для указанного ученика")
+        void success() {
+            setUpGraph();
+            persist(TestData.attendance(STUDENT_2, tuesdayInstance, AttendanceStatus.LATE));
+
+            List<LessonInstance> lessons = lessonInstanceRepository
+                    .findLessonInstanceAttendancesByPeriodAndStudent(
+                            List.of(mondayLesson.getId(), tuesdayLesson.getId()), D1, D2, STUDENT_1);
+
+            assertThat(lessons).extracting(LessonInstance::getId)
+                    .containsExactly(mondayInstance.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("findLessonInstanceHomeworksByPeriodAndStudent")
+    class FindLessonInstanceHomeworksByPeriodAndStudent {
+
+        @Test
+        @DisplayName("возвращает уроки с домашними заданиями (left join)")
+        void success() {
+            setUpGraph();
+            clearAndFlush();
+
+            List<LessonInstance> lessons = lessonInstanceRepository
+                    .findLessonInstanceHomeworksByPeriodAndStudent(
+                            List.of(mondayLesson.getId(), tuesdayLesson.getId()), D1, D2);
+
+            assertThat(lessons).extracting(LessonInstance::getId)
+                    .containsExactly(mondayInstance.getId(), tuesdayInstance.getId());
+            LessonInstance withHomework = lessons.stream()
+                    .filter(li -> li.getId().equals(mondayInstance.getId()))
+                    .findFirst().orElseThrow();
+            assertThat(withHomework.getHomeworks()).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("isOwnedByTeacherAndHasStudent")
+    class IsOwnedByTeacherAndHasStudent {
+
+        @Test
+        @DisplayName("проверяет принадлежность урока учителю и ученику")
+        void success() {
+            setUpGraph();
+
+            assertThat(lessonInstanceRepository
+                    .isOwnedByTeacherAndHasStudent(TEACHER_ID, mondayInstance.getId(), STUDENT_1)).isTrue();
+            assertThat(lessonInstanceRepository
+                    .isOwnedByTeacherAndHasStudent(99L, mondayInstance.getId(), STUDENT_1)).isFalse();
+            assertThat(lessonInstanceRepository
+                    .isOwnedByTeacherAndHasStudent(TEACHER_ID, mondayInstance.getId(), 999L)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isOwnedByTeacher")
+    class IsOwnedByTeacher {
+
+        @Test
+        @DisplayName("проверяет принадлежность урока учителю")
+        void success() {
+            setUpGraph();
+
+            assertThat(lessonInstanceRepository
+                    .isOwnedByTeacher(TEACHER_ID, mondayInstance.getId())).isTrue();
+            assertThat(lessonInstanceRepository
+                    .isOwnedByTeacher(99L, mondayInstance.getId())).isFalse();
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/PeriodGradeRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/PeriodGradeRepositoryIT.java
@@ -1,0 +1,122 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.model.AcademicPeriod;
+import com.rusobr.academic.domain.model.AcademicYear;
+import com.rusobr.academic.domain.model.PeriodGrade;
+import com.rusobr.academic.domain.model.SchoolClass;
+import com.rusobr.academic.domain.model.Subject;
+import com.rusobr.academic.domain.model.TeachingAssignment;
+import com.rusobr.academic.infrastructure.persistence.repository.PeriodGradeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PeriodGradeRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    PeriodGradeRepository periodGradeRepository;
+
+    private static final long STUDENT_ID = 11L;
+    private static final long TEACHER_ID = 7L;
+
+    private AcademicYear year;
+    private AcademicPeriod firstPeriod;
+    private AcademicPeriod secondPeriod;
+    private TeachingAssignment assignment;
+    private TeachingAssignment biologyAssignment;
+
+    private void setUpGraph() {
+        year = persist(TestData.academicYear("2025-2026"));
+        firstPeriod = persist(TestData.academicPeriod(year, "1 четверть",
+                LocalDate.of(2025, 9, 1), LocalDate.of(2025, 10, 31)));
+        secondPeriod = persist(TestData.academicPeriod(year, "2 четверть",
+                LocalDate.of(2025, 11, 10), LocalDate.of(2025, 12, 26)));
+
+        SchoolClass schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+        Subject math = persist(TestData.subject("Математика"));
+        Subject biology = persist(TestData.subject("Биология"));
+        assignment = persist(TestData.assignment(TEACHER_ID, schoolClass, math));
+        biologyAssignment = persist(TestData.assignment(TEACHER_ID, schoolClass, biology));
+    }
+
+    @Nested
+    @DisplayName("findWithAcademicPeriodById")
+    class FindWithAcademicPeriodById {
+
+        @Test
+        @DisplayName("загружает учебный период оценки")
+        void success() {
+            setUpGraph();
+            PeriodGrade grade = persist(TestData.periodGrade(STUDENT_ID, firstPeriod, assignment, 4));
+            clearAndFlush();
+
+            Optional<PeriodGrade> found = periodGradeRepository.findWithAcademicPeriodById(grade.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getAcademicPeriod().getName()).isEqualTo("1 четверть");
+        }
+    }
+
+    @Nested
+    @DisplayName("findPeriodGradeByStudentId")
+    class FindPeriodGradeByStudentId {
+
+        @Test
+        @DisplayName("возвращает оценки ученика, отсортированные по периоду и предмету")
+        void success() {
+            setUpGraph();
+            persist(TestData.periodGrade(STUDENT_ID, secondPeriod, assignment, 5));
+            persist(TestData.periodGrade(STUDENT_ID, firstPeriod, assignment, 4));
+            persist(TestData.periodGrade(STUDENT_ID, firstPeriod, biologyAssignment, 3));
+
+            List<PeriodGrade> grades = periodGradeRepository
+                    .findPeriodGradeByStudentId(STUDENT_ID, year.getId());
+
+            assertThat(grades).hasSize(3);
+            assertThat(grades).extracting(PeriodGrade::getValue).containsExactly(3, 4, 5);
+        }
+    }
+
+    @Nested
+    @DisplayName("findPeriodGradesByTeachingAssignmentId")
+    class FindPeriodGradesByTeachingAssignmentId {
+
+        @Test
+        @DisplayName("фильтрует оценки по назначению и году")
+        void success() {
+            setUpGraph();
+            persist(TestData.periodGrade(STUDENT_ID, firstPeriod, assignment, 4));
+            persist(TestData.periodGrade(STUDENT_ID, secondPeriod, assignment, 5));
+            persist(TestData.periodGrade(STUDENT_ID, firstPeriod, biologyAssignment, 3));
+
+            List<PeriodGrade> grades = periodGradeRepository
+                    .findPeriodGradesByTeachingAssignmentId(assignment.getId(), year.getId());
+
+            assertThat(grades).hasSize(2);
+            assertThat(grades).extracting(PeriodGrade::getValue).containsExactly(4, 5);
+        }
+    }
+
+    @Nested
+    @DisplayName("isPeriodGradeOwnedByTeacher")
+    class IsPeriodGradeOwnedByTeacher {
+
+        @Test
+        @DisplayName("возвращает true для учителя предмета и false для другого")
+        void success() {
+            setUpGraph();
+            PeriodGrade grade = persist(TestData.periodGrade(STUDENT_ID, firstPeriod, assignment, 4));
+
+            assertThat(periodGradeRepository.isPeriodGradeOwnedByTeacher(TEACHER_ID, grade.getId())).isTrue();
+            assertThat(periodGradeRepository.isPeriodGradeOwnedByTeacher(99L, grade.getId())).isFalse();
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/ScheduleLessonRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/ScheduleLessonRepositoryIT.java
@@ -1,0 +1,288 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.model.LessonInstance;
+import com.rusobr.academic.domain.model.ScheduleLesson;
+import com.rusobr.academic.domain.model.SchoolClass;
+import com.rusobr.academic.domain.model.Subject;
+import com.rusobr.academic.domain.model.TeachingAssignment;
+import com.rusobr.academic.infrastructure.persistence.projection.ScheduleLessonProjection;
+import com.rusobr.academic.infrastructure.persistence.projection.SchoolLessonProjection;
+import com.rusobr.academic.infrastructure.persistence.repository.ScheduleLessonRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ScheduleLessonRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    ScheduleLessonRepository scheduleLessonRepository;
+
+    private static final long STUDENT_ID = 11L;
+    private static final long TEACHER_ID = 7L;
+    private static final LocalDate NOW = LocalDate.of(2025, 9, 15);
+
+    private TeachingAssignment assignment;
+    private ScheduleLesson mondayLesson;
+    private ScheduleLesson tuesdayLesson;
+    private ScheduleLesson expiredLesson;
+
+    private void setUpGraph() {
+        var year = persist(TestData.academicYear("2025-2026"));
+        SchoolClass schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+        persist(TestData.classStudent(schoolClass, STUDENT_ID));
+        Subject subject = persist(TestData.subject("Математика"));
+        Subject biology = persist(TestData.subject("Биология"));
+        assignment = persist(TestData.assignment(TEACHER_ID, schoolClass, subject));
+        TeachingAssignment otherAssignment = persist(TestData.assignment(TEACHER_ID, schoolClass, biology));
+
+        mondayLesson = persist(ScheduleLesson.builder()
+                .teachingAssignment(assignment)
+                .dayOfWeek(DayOfWeek.MONDAY)
+                .lessonNumber(1)
+                .classRoom("101")
+                .validFrom(TestData.SEPTEMBER)
+                .build());
+        tuesdayLesson = persist(ScheduleLesson.builder()
+                .teachingAssignment(assignment)
+                .dayOfWeek(DayOfWeek.TUESDAY)
+                .lessonNumber(2)
+                .classRoom("102")
+                .validFrom(TestData.SEPTEMBER)
+                .build());
+        expiredLesson = persist(ScheduleLesson.builder()
+                .teachingAssignment(otherAssignment)
+                .dayOfWeek(DayOfWeek.MONDAY)
+                .lessonNumber(3)
+                .classRoom("103")
+                .validFrom(TestData.SEPTEMBER)
+                .validTo(LocalDate.of(2025, 9, 10))
+                .build());
+    }
+
+    @Nested
+    @DisplayName("getScheduleByDate")
+    class GetScheduleByDate {
+
+        @Test
+        @DisplayName("возвращает активные уроки расписания на день")
+        void success() {
+            setUpGraph();
+
+            List<ScheduleLessonProjection> schedule = scheduleLessonRepository
+                    .getScheduleByDate(STUDENT_ID, DayOfWeek.MONDAY, NOW);
+
+            assertThat(schedule).hasSize(1);
+            assertThat(schedule.get(0).getLessonNumber()).isEqualTo(1);
+            assertThat(schedule.get(0).getSubjectName()).isEqualTo("Математика");
+            assertThat(schedule.get(0).getClassRoom()).isEqualTo("101");
+        }
+
+        @Test
+        @DisplayName("исключает устаревшие уроки и уроки других дней")
+        void excludesExpiredAndOtherDays() {
+            setUpGraph();
+
+            List<ScheduleLessonProjection> schedule = scheduleLessonRepository
+                    .getScheduleByDate(STUDENT_ID, DayOfWeek.TUESDAY, NOW);
+
+            assertThat(schedule).hasSize(1);
+            assertThat(schedule.get(0).getLessonNumber()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByStudentId")
+    class FindAllByStudentId {
+
+        @Test
+        @DisplayName("возвращает все уроки класса ученика")
+        void success() {
+            setUpGraph();
+
+            List<SchoolLessonProjection> lessons = scheduleLessonRepository.findAllByStudentId(STUDENT_ID);
+
+            assertThat(lessons).hasSize(3);
+            assertThat(lessons).extracting(SchoolLessonProjection::getLessonNumber)
+                    .containsExactlyInAnyOrder(1, 2, 3);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByTeachingAssignmentId")
+    class FindByTeachingAssignmentId {
+
+        @Test
+        @DisplayName("фильтрует уроки по назначению")
+        void success() {
+            setUpGraph();
+
+            List<ScheduleLesson> lessons = scheduleLessonRepository.findByTeachingAssignmentId(assignment.getId());
+
+            assertThat(lessons).extracting(ScheduleLesson::getId)
+                    .containsExactlyInAnyOrder(mondayLesson.getId(), tuesdayLesson.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("findClassSchedule")
+    class FindClassSchedule {
+
+        @Test
+        @DisplayName("возвращает активные отсортированные уроки класса")
+        void success() {
+            setUpGraph();
+
+            List<ScheduleLesson> lessons = scheduleLessonRepository.findClassSchedule(assignment.getSchoolClass().getId(), NOW);
+
+            assertThat(lessons).extracting(ScheduleLesson::getLessonNumber).containsExactly(1, 2);
+            assertThat(lessons).allSatisfy(sl -> assertThat(sl.getTeachingAssignment()).isNotNull());
+        }
+    }
+
+    @Nested
+    @DisplayName("findWithTeachingAssignmentById")
+    class FindWithTeachingAssignmentById {
+
+        @Test
+        @DisplayName("загружает назначение урока")
+        void success() {
+            setUpGraph();
+            clearAndFlush();
+
+            Optional<ScheduleLesson> found = scheduleLessonRepository.findWithTeachingAssignmentById(mondayLesson.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getTeachingAssignment().getId()).isEqualTo(assignment.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("existsActiveByClassSlot")
+    class ExistsActiveByClassSlot {
+
+        @Test
+        @DisplayName("проверяет занятость слота класса")
+        void success() {
+            setUpGraph();
+
+            long classId = assignment.getSchoolClass().getId();
+            assertThat(scheduleLessonRepository
+                    .existsActiveByClassSlot(classId, DayOfWeek.MONDAY, 1, NOW)).isTrue();
+            assertThat(scheduleLessonRepository
+                    .existsActiveByClassSlot(classId, DayOfWeek.MONDAY, 5, NOW)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("existsActiveByTeachingAssignmentSlot")
+    class ExistsActiveByTeachingAssignmentSlot {
+
+        @Test
+        @DisplayName("проверяет занятость слота назначения")
+        void success() {
+            setUpGraph();
+
+            assertThat(scheduleLessonRepository
+                    .existsActiveByTeachingAssignmentSlot(assignment.getId(), DayOfWeek.MONDAY, 1, NOW)).isTrue();
+            assertThat(scheduleLessonRepository
+                    .existsActiveByTeachingAssignmentSlot(assignment.getId(), DayOfWeek.FRIDAY, 1, NOW)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByClassIdAndPeriod")
+    class FindAllByClassIdAndPeriod {
+
+        @Test
+        @DisplayName("возвращает уроки класса, пересекающие период")
+        void success() {
+            setUpGraph();
+
+            List<ScheduleLesson> lessons = scheduleLessonRepository
+                    .findAllByClassIdAndPeriod(assignment.getSchoolClass().getId(),
+                            LocalDate.of(2025, 9, 1), LocalDate.of(2025, 9, 30));
+
+            assertThat(lessons).hasSize(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByTeacherSlot")
+    class ExistsByTeacherSlot {
+
+        @Test
+        @DisplayName("проверяет занятость учителя в слоте")
+        void success() {
+            setUpGraph();
+
+            assertThat(scheduleLessonRepository
+                    .existsByTeacherSlot(TEACHER_ID, DayOfWeek.MONDAY, 1, NOW)).isTrue();
+            assertThat(scheduleLessonRepository
+                    .existsByTeacherSlot(TEACHER_ID, DayOfWeek.MONDAY, 5, NOW)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findDiaryScheduleByStudentId")
+    class FindDiaryScheduleByStudentId {
+
+        @Test
+        @DisplayName("возвращает уроки ученика, пересекающие период")
+        void success() {
+            setUpGraph();
+
+            List<ScheduleLesson> lessons = scheduleLessonRepository
+                    .findDiaryScheduleByStudentId(STUDENT_ID,
+                            LocalDate.of(2025, 9, 1), LocalDate.of(2025, 9, 30));
+
+            assertThat(lessons).extracting(ScheduleLesson::getLessonNumber).containsExactly(1, 2, 3);
+            assertThat(lessons).allSatisfy(sl -> assertThat(sl.getTeachingAssignment()).isNotNull());
+        }
+    }
+
+    @Nested
+    @DisplayName("findTeacherScheduleByDate")
+    class FindTeacherScheduleByDate {
+
+        @Test
+        @DisplayName("возвращает экземпляры уроков учителя на дату")
+        void success() {
+            setUpGraph();
+            LessonInstance mondayInstance = persist(TestData.lessonInstance(mondayLesson, NOW));
+
+            List<LessonInstance> instances = scheduleLessonRepository.findTeacherScheduleByDate(TEACHER_ID, NOW);
+
+            assertThat(instances).extracting(LessonInstance::getId)
+                    .containsExactly(mondayInstance.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("findTeacherScheduleByPeriod")
+    class FindTeacherScheduleByPeriod {
+
+        @Test
+        @DisplayName("возвращает экземпляры уроков учителя за период")
+        void success() {
+            setUpGraph();
+            LessonInstance mondayInstance = persist(TestData.lessonInstance(mondayLesson, NOW));
+            persist(TestData.lessonInstance(tuesdayLesson, NOW.plusDays(1)));
+
+            List<LessonInstance> instances = scheduleLessonRepository
+                    .findTeacherScheduleByPeriod(TEACHER_ID, NOW, NOW.plusDays(7));
+
+            assertThat(instances).hasSize(2);
+            assertThat(instances).extracting(LessonInstance::getId)
+                    .contains(mondayInstance.getId());
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/SchoolClassRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/SchoolClassRepositoryIT.java
@@ -1,0 +1,250 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.model.AcademicYear;
+import com.rusobr.academic.domain.model.SchoolClass;
+import com.rusobr.academic.infrastructure.persistence.repository.SchoolClassRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SchoolClassRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    SchoolClassRepository schoolClassRepository;
+
+    @Nested
+    @DisplayName("findStudentIdsFromSchoolClasses")
+    class FindStudentIdsFromSchoolClasses {
+
+        @Test
+        @DisplayName("возвращает id учеников класса")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            persist(TestData.classStudent(schoolClass, 11L));
+            persist(TestData.classStudent(schoolClass, 12L));
+
+            List<Long> studentIds = schoolClassRepository.findStudentIdsFromSchoolClasses(schoolClass.getId());
+
+            assertThat(studentIds).containsExactlyInAnyOrder(11L, 12L);
+        }
+    }
+
+    @Nested
+    @DisplayName("findSchoolClassByStudentId")
+    class FindSchoolClassByStudentId {
+
+        @Test
+        @DisplayName("находит класс ученика")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            persist(TestData.classStudent(schoolClass, 11L));
+
+            Optional<SchoolClass> found = schoolClassRepository.findSchoolClassByStudentId(11L);
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getName()).isEqualTo("5А");
+            assertThat(found.get().getAcademicYear()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("findStudentsIdsByTeachingAssignment")
+    class FindStudentsIdsByTeachingAssignment {
+
+        @Test
+        @DisplayName("возвращает id учеников по назначению")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            persist(TestData.classStudent(schoolClass, 11L));
+            persist(TestData.classStudent(schoolClass, 12L));
+            var subject = persist(TestData.subject("Математика"));
+            var assignment = persist(TestData.assignment(7L, schoolClass, subject));
+
+            List<Long> studentIds = schoolClassRepository
+                    .findStudentsIdsByTeachingAssignment(assignment.getId());
+
+            assertThat(studentIds).containsExactlyInAnyOrder(11L, 12L);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByAcademicYearIdOrderByNameAsc")
+    class FindAllByAcademicYearIdOrderByNameAsc {
+
+        @Test
+        @DisplayName("фильтрует по году и сортирует по имени")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var otherYear = persist(AcademicYear.builder()
+                    .name("2024-2025")
+                    .startDate(LocalDate.of(2024, 9, 1))
+                    .endDate(LocalDate.of(2025, 5, 31))
+                    .build());
+            persist(TestData.schoolClass(year, "5Б", 42L));
+            persist(TestData.schoolClass(year, "5А", 43L));
+            persist(TestData.schoolClass(otherYear, "5В", 44L));
+
+            List<SchoolClass> classes = schoolClassRepository
+                    .findAllByAcademicYearIdOrderByNameAsc(year.getId());
+
+            assertThat(classes).extracting(SchoolClass::getName).containsExactly("5А", "5Б");
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByOrderByNameAsc")
+    class FindAllByOrderByNameAsc {
+
+        @Test
+        @DisplayName("загружает учебный год и сортирует по имени")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            persist(TestData.schoolClass(year, "5Б", 42L));
+            persist(TestData.schoolClass(year, "5А", 43L));
+
+            List<SchoolClass> classes = schoolClassRepository.findAllByOrderByNameAsc();
+
+            assertThat(classes).extracting(SchoolClass::getName).containsExactly("5А", "5Б");
+            assertThat(classes).allSatisfy(sc -> assertThat(sc.getAcademicYear()).isNotNull());
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByNameAndAcademicYearId")
+    class ExistsByNameAndAcademicYearId {
+
+        @Test
+        @DisplayName("проверяет уникальность имени в пределах года")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            persist(TestData.schoolClass(year, "5А", 42L));
+
+            assertThat(schoolClassRepository.existsByNameAndAcademicYearId("5А", year.getId())).isTrue();
+            assertThat(schoolClassRepository.existsByNameAndAcademicYearId("5Б", year.getId())).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByNameAndIdNot")
+    class ExistsByNameAndIdNot {
+
+        @Test
+        @DisplayName("игнорирует собственный id при проверке")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            persist(TestData.schoolClass(year, "5Б", 43L));
+
+            assertThat(schoolClassRepository.existsByNameAndIdNot("5А", schoolClass.getId())).isFalse();
+            assertThat(schoolClassRepository.existsByNameAndIdNot("5Б", schoolClass.getId())).isTrue();
+            assertThat(schoolClassRepository.existsByNameAndIdNot("5А", 999_999L)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByNameAndAcademicYearIdAndIdNot")
+    class ExistsByNameAndAcademicYearIdAndIdNot {
+
+        @Test
+        @DisplayName("комбинирует имя, год и исключение собственного id")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+
+            assertThat(schoolClassRepository
+                    .existsByNameAndAcademicYearIdAndIdNot("5А", year.getId(), schoolClass.getId())).isFalse();
+            assertThat(schoolClassRepository
+                    .existsByNameAndAcademicYearIdAndIdNot("5А", year.getId(), 999_999L)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("findWithClassStudentById")
+    class FindWithClassStudentById {
+
+        @Test
+        @DisplayName("загружает учеников класса")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            persist(TestData.classStudent(schoolClass, 11L));
+            clearAndFlush();
+
+            Optional<SchoolClass> found = schoolClassRepository.findWithClassStudentById(schoolClass.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getStudents())
+                    .extracting(cs -> cs.getStudentId())
+                    .containsExactlyInAnyOrder(11L);
+        }
+    }
+
+    @Nested
+    @DisplayName("findWithAcademicYearById")
+    class FindWithAcademicYearById {
+
+        @Test
+        @DisplayName("загружает учебный год класса")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            clearAndFlush();
+
+            Optional<SchoolClass> found = schoolClassRepository.findWithAcademicYearById(schoolClass.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getAcademicYear().getName()).isEqualTo("2025-2026");
+        }
+    }
+
+    @Nested
+    @DisplayName("findSchoolClassesBySchoolClassTeacherId")
+    class FindSchoolClassesBySchoolClassTeacherId {
+
+        @Test
+        @DisplayName("возвращает классы классного руководителя")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            persist(TestData.schoolClass(year, "5А", 42L));
+            persist(TestData.schoolClass(year, "5Б", 42L));
+            persist(TestData.schoolClass(year, "5В", 43L));
+
+            List<SchoolClass> classes = schoolClassRepository.findSchoolClassesBySchoolClassTeacherId(42L);
+
+            assertThat(classes).extracting(SchoolClass::getName).containsExactly("5А", "5Б");
+        }
+    }
+
+    @Nested
+    @DisplayName("findSchoolClassesTeacherId")
+    class FindSchoolClassesTeacherId {
+
+        @Test
+        @DisplayName("возвращает уникальные классы учителя")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var classA = persist(TestData.schoolClass(year, "5А", 42L));
+            var classB = persist(TestData.schoolClass(year, "5Б", 42L));
+            var subject = persist(TestData.subject("Математика"));
+            var subject2 = persist(TestData.subject("Физика"));
+            persist(TestData.assignment(7L, classA, subject));
+            persist(TestData.assignment(7L, classA, subject2));
+            persist(TestData.assignment(7L, classB, subject));
+
+            List<SchoolClass> classes = schoolClassRepository.findSchoolClassesTeacherId(7L);
+
+            assertThat(classes).extracting(SchoolClass::getName).containsExactly("5А", "5Б");
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/SubjectRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/SubjectRepositoryIT.java
@@ -1,0 +1,75 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.model.Subject;
+import com.rusobr.academic.infrastructure.persistence.projection.SubjectResponseProjection;
+import com.rusobr.academic.infrastructure.persistence.repository.SubjectRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SubjectRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    SubjectRepository subjectRepository;
+
+    @Nested
+    @DisplayName("findAllByOrderByNameAsc")
+    class FindAllByOrderByNameAsc {
+
+        @Test
+        @DisplayName("возвращает предметы, отсортированные по имени")
+        void success() {
+            persist(TestData.subject("Химия"));
+            persist(TestData.subject("Алгебра"));
+
+            Pageable pageable = PageRequest.of(0, 10);
+            Page<SubjectResponseProjection> page = subjectRepository.findAllByOrderByNameAsc(pageable);
+
+            assertThat(page.getContent())
+                    .extracting(SubjectResponseProjection::getName)
+                    .containsExactly("Алгебра", "Химия");
+        }
+    }
+
+    @Nested
+    @DisplayName("findById")
+    class FindById {
+
+        @Test
+        @DisplayName("возвращает предмет по id")
+        void success() {
+            Subject subject = persist(TestData.subject("Физика"));
+
+            Optional<Subject> found = subjectRepository.findById(subject.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getName()).isEqualTo("Физика");
+        }
+    }
+
+    @Nested
+    @DisplayName("softDelete")
+    class SoftDelete {
+
+        @Test
+        @DisplayName("исключает удалённый предмет из выборок")
+        void success() {
+            Subject subject = persist(TestData.subject("История"));
+
+            subjectRepository.deleteById(subject.getId());
+            clearAndFlush();
+
+            assertThat(subjectRepository.findById(subject.getId())).isNotPresent();
+            assertThat(subjectRepository.findAll()).isEmpty();
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/TeacherSubjectRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/TeacherSubjectRepositoryIT.java
@@ -1,0 +1,67 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.model.Subject;
+import com.rusobr.academic.domain.model.TeacherSubject;
+import com.rusobr.academic.domain.model.TeacherSubjectId;
+import com.rusobr.academic.infrastructure.persistence.repository.TeacherSubjectRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TeacherSubjectRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    TeacherSubjectRepository teacherSubjectRepository;
+
+    @Nested
+    @DisplayName("findByTeacherId")
+    class FindByTeacherId {
+
+        @Test
+        @DisplayName("возвращает предметы учителя, отсортированные по имени")
+        void success() {
+            Subject algebra = persist(TestData.subject("Алгебра"));
+            Subject physics = persist(TestData.subject("Физика"));
+            persist(TestData.teacherSubject(7L, physics));
+            persist(TestData.teacherSubject(7L, algebra));
+            persist(TestData.teacherSubject(8L, algebra));
+
+            List<TeacherSubject> teacherSubjects = teacherSubjectRepository.findByTeacherId(7L);
+
+            assertThat(teacherSubjects)
+                    .extracting(ts -> ts.getSubject().getName())
+                    .containsExactly("Алгебра", "Физика");
+        }
+    }
+
+    @Nested
+    @DisplayName("softDelete")
+    class SoftDelete {
+
+        @Test
+        @DisplayName("помечает запись удалённой и исключает её из активных запросов")
+        void success() {
+            Subject algebra = persist(TestData.subject("Алгебра"));
+            TeacherSubject teacherSubject = persist(TestData.teacherSubject(7L, algebra));
+            TeacherSubjectId id = teacherSubject.getId();
+
+            teacherSubjectRepository.softDelete(id.getSubjectId(), id.getTeacherId());
+            clearAndFlush();
+
+            assertThat(teacherSubjectRepository.findById(id)).isNotPresent();
+            assertThat(teacherSubjectRepository.findByTeacherId(7L)).isEmpty();
+
+            Optional<TeacherSubject> withDeleted = teacherSubjectRepository
+                    .findByIdWithDeleted(id.getSubjectId(), id.getTeacherId());
+            assertThat(withDeleted).isPresent();
+            assertThat(withDeleted.get().getDeletedAt()).isNotNull();
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/TeachingAssignmentRepositoryIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/TeachingAssignmentRepositoryIT.java
@@ -1,0 +1,176 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.model.AcademicYear;
+import com.rusobr.academic.domain.model.SchoolClass;
+import com.rusobr.academic.domain.model.Subject;
+import com.rusobr.academic.domain.model.TeachingAssignment;
+import com.rusobr.academic.infrastructure.persistence.projection.TeachingAssignmentDetailsProjection;
+import com.rusobr.academic.infrastructure.persistence.repository.TeachingAssignmentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TeachingAssignmentRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    TeachingAssignmentRepository teachingAssignmentRepository;
+
+    @Nested
+    @DisplayName("findByIdWithClassId")
+    class FindByIdWithClassId {
+
+        @Test
+        @DisplayName("возвращает id класса назначения")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            var subject = persist(TestData.subject("Математика"));
+            var assignment = persist(TestData.assignment(7L, schoolClass, subject));
+
+            Optional<Long> classId = teachingAssignmentRepository.findByIdWithClassId(assignment.getId());
+
+            assertThat(classId).hasValue(schoolClass.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("findTeachingAssignmentDetailByTeacherId")
+    class FindTeachingAssignmentDetailByTeacherId {
+
+        @Test
+        @DisplayName("возвращает детали назначений, отсортированные по предмету и классу")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var classA = persist(TestData.schoolClass(year, "5Б", 42L));
+            var classB = persist(TestData.schoolClass(year, "5А", 42L));
+            var algebra = persist(TestData.subject("Алгебра"));
+            var physics = persist(TestData.subject("Физика"));
+            persist(TestData.assignment(7L, classA, physics));
+            persist(TestData.assignment(7L, classB, algebra));
+            persist(TestData.assignment(8L, classA, algebra));
+
+            List<TeachingAssignmentDetailsProjection> details =
+                    teachingAssignmentRepository.findTeachingAssignmentDetailByTeacherId(7L);
+
+            assertThat(details).hasSize(2);
+            assertThat(details)
+                    .extracting(TeachingAssignmentDetailsProjection::getSubjectName)
+                    .containsExactly("Алгебра", "Физика");
+            assertThat(details)
+                    .extracting(TeachingAssignmentDetailsProjection::getSchoolClassName)
+                    .containsExactly("5А", "5Б");
+            assertThat(details.get(0).getSchoolClassId()).isEqualTo(classB.getId());
+            assertThat(details.get(0).getSubjectId()).isEqualTo(algebra.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("findBySubjectIdAndSchoolClassIdAndTeacherId")
+    class FindBySubjectIdAndSchoolClassIdAndTeacherId {
+
+        @Test
+        @DisplayName("находит точное назначение по предмету, классу и учителю")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            var subject = persist(TestData.subject("Математика"));
+            persist(TestData.assignment(7L, schoolClass, subject));
+
+            Optional<TeachingAssignment> found = teachingAssignmentRepository
+                    .findBySubjectIdAndSchoolClassIdAndTeacherId(subject.getId(), schoolClass.getId(), 7L);
+
+            assertThat(found).isPresent();
+            assertThat(teachingAssignmentRepository
+                    .findBySubjectIdAndSchoolClassIdAndTeacherId(subject.getId(), schoolClass.getId(), 8L)).isNotPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("findStudentIdsByTeachingAssignmentId")
+    class FindStudentIdsByTeachingAssignmentId {
+
+        @Test
+        @DisplayName("возвращает id учеников класса назначения")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            persist(TestData.classStudent(schoolClass, 11L));
+            persist(TestData.classStudent(schoolClass, 12L));
+            var subject = persist(TestData.subject("Математика"));
+            var assignment = persist(TestData.assignment(7L, schoolClass, subject));
+
+            List<Long> studentIds = teachingAssignmentRepository
+                    .findStudentIdsByTeachingAssignmentId(assignment.getId());
+
+            assertThat(studentIds).containsExactlyInAnyOrder(11L, 12L);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByTeacherId")
+    class FindByTeacherId {
+
+        @Test
+        @DisplayName("загружает предмет и класс назначения")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            var subject = persist(TestData.subject("Математика"));
+            persist(TestData.assignment(7L, schoolClass, subject));
+            clearAndFlush();
+
+            List<TeachingAssignment> assignments = teachingAssignmentRepository.findByTeacherId(7L);
+
+            assertThat(assignments).hasSize(1);
+            assertThat(assignments.get(0).getSubject().getName()).isEqualTo("Математика");
+            assertThat(assignments.get(0).getSchoolClass().getName()).isEqualTo("5А");
+        }
+    }
+
+    @Nested
+    @DisplayName("isTeacherOwnedAssignment")
+    class IsTeacherOwnedAssignment {
+
+        @Test
+        @DisplayName("возвращает true для учителя назначения и false для другого")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            var subject = persist(TestData.subject("Математика"));
+            var assignment = persist(TestData.assignment(7L, schoolClass, subject));
+
+            assertThat(teachingAssignmentRepository.isTeacherOwnedAssignment(7L, assignment.getId())).isTrue();
+            assertThat(teachingAssignmentRepository.isTeacherOwnedAssignment(8L, assignment.getId())).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isOwnedByTeacherWithStudent")
+    class IsOwnedByTeacherWithStudent {
+
+        @Test
+        @DisplayName("проверяет принадлежность назначения учителю и ученику")
+        void success() {
+            var year = persist(TestData.academicYear("2025-2026"));
+            var schoolClass = persist(TestData.schoolClass(year, "5А", 42L));
+            persist(TestData.classStudent(schoolClass, 11L));
+            persist(TestData.classStudent(schoolClass, 12L));
+            var subject = persist(TestData.subject("Математика"));
+            var assignment = persist(TestData.assignment(7L, schoolClass, subject));
+
+            assertThat(teachingAssignmentRepository
+                    .isOwnedByTeacherWithStudent(7L, assignment.getId(), 11L)).isTrue();
+            assertThat(teachingAssignmentRepository
+                    .isOwnedByTeacherWithStudent(8L, assignment.getId(), 11L)).isFalse();
+            assertThat(teachingAssignmentRepository
+                    .isOwnedByTeacherWithStudent(7L, assignment.getId(), 99L)).isFalse();
+        }
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/TestData.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/jpaIT/TestData.java
@@ -1,0 +1,148 @@
+package com.rusobr.academic.jpaIT;
+
+import com.rusobr.academic.domain.enums.AttendanceStatus;
+import com.rusobr.academic.domain.enums.GradeType;
+import com.rusobr.academic.domain.model.AcademicPeriod;
+import com.rusobr.academic.domain.model.AcademicYear;
+import com.rusobr.academic.domain.model.Attendance;
+import com.rusobr.academic.domain.model.ClassStudent;
+import com.rusobr.academic.domain.model.FinalGrade;
+import com.rusobr.academic.domain.model.Grade;
+import com.rusobr.academic.domain.model.Homework;
+import com.rusobr.academic.domain.model.LessonInstance;
+import com.rusobr.academic.domain.model.PeriodGrade;
+import com.rusobr.academic.domain.model.ScheduleLesson;
+import com.rusobr.academic.domain.model.SchoolClass;
+import com.rusobr.academic.domain.model.Subject;
+import com.rusobr.academic.domain.model.TeacherSubject;
+import com.rusobr.academic.domain.model.TeacherSubjectId;
+import com.rusobr.academic.domain.model.TeachingAssignment;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+public final class TestData {
+
+    public static final LocalDate SEPTEMBER = LocalDate.of(2025, 9, 1);
+
+    private TestData() {
+    }
+
+    public static AcademicYear academicYear(String name) {
+        return AcademicYear.builder()
+                .name(name)
+                .startDate(LocalDate.of(2025, 9, 1))
+                .endDate(LocalDate.of(2026, 5, 31))
+                .build();
+    }
+
+    public static AcademicPeriod academicPeriod(AcademicYear year, String name, LocalDate start, LocalDate end) {
+        return AcademicPeriod.builder()
+                .name(name)
+                .academicYear(year)
+                .startDate(start)
+                .endDate(end)
+                .build();
+    }
+
+    public static Subject subject(String name) {
+        return Subject.builder()
+                .name(name)
+                .build();
+    }
+
+    public static SchoolClass schoolClass(AcademicYear year, String name, long classTeacherId) {
+        return SchoolClass.builder()
+                .name(name)
+                .academicYear(year)
+                .classTeacherId(classTeacherId)
+                .build();
+    }
+
+    public static ClassStudent classStudent(SchoolClass schoolClass, long studentId) {
+        ClassStudent classStudent = ClassStudent.builder()
+                .studentId(studentId)
+                .schoolClass(schoolClass)
+                .build();
+        schoolClass.getStudents().add(classStudent);
+        return classStudent;
+    }
+
+    public static TeachingAssignment assignment(long teacherId, SchoolClass schoolClass, Subject subject) {
+        return TeachingAssignment.builder()
+                .teacherId(teacherId)
+                .schoolClass(schoolClass)
+                .subject(subject)
+                .build();
+    }
+
+    public static ScheduleLesson scheduleLesson(TeachingAssignment assignment, DayOfWeek dayOfWeek, int lessonNumber) {
+        return ScheduleLesson.builder()
+                .teachingAssignment(assignment)
+                .dayOfWeek(dayOfWeek)
+                .lessonNumber(lessonNumber)
+                .classRoom("101")
+                .validFrom(SEPTEMBER)
+                .build();
+    }
+
+    public static LessonInstance lessonInstance(ScheduleLesson scheduleLesson, LocalDate lessonDate) {
+        return LessonInstance.builder()
+                .scheduleLesson(scheduleLesson)
+                .lessonDate(lessonDate)
+                .build();
+    }
+
+    public static Grade grade(long studentId, LessonInstance lessonInstance, int value, int weight, GradeType type) {
+        return Grade.builder()
+                .studentId(studentId)
+                .lessonInstance(lessonInstance)
+                .value(value)
+                .weight(weight)
+                .type(type)
+                .build();
+    }
+
+    public static Attendance attendance(long studentId, LessonInstance lessonInstance, AttendanceStatus status) {
+        return Attendance.builder()
+                .studentId(studentId)
+                .lessonInstance(lessonInstance)
+                .status(status)
+                .build();
+    }
+
+    public static Homework homework(LessonInstance lessonInstance, String text) {
+        return Homework.builder()
+                .lessonInstance(lessonInstance)
+                .text(text)
+                .build();
+    }
+
+    public static PeriodGrade periodGrade(long studentId, AcademicPeriod period, TeachingAssignment assignment, int value) {
+        return PeriodGrade.builder()
+                .studentId(studentId)
+                .academicPeriod(period)
+                .teachingAssignment(assignment)
+                .value(value)
+                .build();
+    }
+
+    public static FinalGrade finalGrade(long studentId, AcademicYear year, TeachingAssignment assignment, int value) {
+        return FinalGrade.builder()
+                .studentId(studentId)
+                .academicYear(year)
+                .teachingAssignment(assignment)
+                .value(value)
+                .build();
+    }
+
+    public static TeacherSubject teacherSubject(long teacherId, Subject subject) {
+        TeacherSubject teacherSubject = TeacherSubject.builder()
+                .id(TeacherSubjectId.builder().teacherId(teacherId).subjectId(null).build())
+                .subject(subject)
+                .build();
+        teacherSubject.getId().setSubjectId(subject.getId());
+        return teacherSubject;
+    }
+
+}

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
@@ -48,6 +51,7 @@ dependencies {
     implementation 'io.github.openfeign:feign-micrometer'
     implementation 'io.micrometer:context-propagation'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
 
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }

--- a/backend/user-service/src/test/java/com/rusobr/user/jpaIT/AbstractRepositoryIT.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/jpaIT/AbstractRepositoryIT.java
@@ -1,0 +1,41 @@
+package com.rusobr.user.jpaIT;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class AbstractRepositoryIT {
+
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    static {
+        POSTGRES.start();
+    }
+
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
+    }
+
+    @Autowired
+    protected TestEntityManager em;
+
+    protected <T> T persist(T entity) {
+        return em.persistAndFlush(entity);
+    }
+
+    protected void clearAndFlush() {
+        em.flush();
+        em.clear();
+    }
+
+}

--- a/backend/user-service/src/test/java/com/rusobr/user/jpaIT/ParentRepositoryIT.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/jpaIT/ParentRepositoryIT.java
@@ -1,0 +1,120 @@
+package com.rusobr.user.jpaIT;
+
+import com.rusobr.user.domain.model.Parent;
+import com.rusobr.user.domain.model.Student;
+import com.rusobr.user.domain.model.User;
+import com.rusobr.user.infrastructure.persistence.repository.ParentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParentRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    ParentRepository parentRepository;
+
+    private Parent persistParent(String username) {
+        User user = persist(TestData.user(username, "Ольга", "Сидорова"));
+        return persist(TestData.parent(user));
+    }
+
+    @Nested
+    @DisplayName("findWithUserById")
+    class FindWithUserById {
+
+        @Test
+        @DisplayName("возвращает родителя вместе с пользователем и детьми")
+        void success() {
+            Parent parent = persistParent("parent1");
+            User childUser = persist(TestData.user("child1", "Иван", "Сидоров"));
+            Student child = persist(TestData.student(childUser, "math", parent));
+            clearAndFlush();
+
+            Optional<Parent> found = parentRepository.findWithUserById(parent.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getUser().getUsername()).isEqualTo("parent1");
+            assertThat(found.get().getChildren())
+                    .extracting(Student::getId)
+                    .containsExactly(child.getId());
+        }
+
+        @Test
+        @DisplayName("возвращает родителя с пользователем, даже если детей нет")
+        void withoutChildren() {
+            Parent parent = persistParent("parent1");
+
+            Optional<Parent> found = parentRepository.findWithUserById(parent.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getUser().getUsername()).isEqualTo("parent1");
+            assertThat(found.get().getChildren()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdWithDeleted")
+    class FindByIdWithDeleted {
+
+        @Test
+        @DisplayName("возвращает родителя, даже если он мягко удалён")
+        void success() {
+            Parent parent = persistParent("parent1");
+
+            parentRepository.deleteById(parent.getId());
+            clearAndFlush();
+
+            Optional<Parent> withDeleted = parentRepository.findByIdWithDeleted(parent.getId());
+
+            assertThat(withDeleted).isPresent();
+            assertThat(withDeleted.get().getDeletedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("findParentInfoById")
+    class FindParentInfoById {
+
+        @Test
+        @DisplayName("возвращает родителя вместе с детьми и их пользователями")
+        void success() {
+            Parent parent = persistParent("parent1");
+            User childUser = persist(TestData.user("child1", "Иван", "Сидоров"));
+            Student child = persist(TestData.student(childUser, "math", parent));
+            clearAndFlush();
+
+            Optional<Parent> found = parentRepository.findParentInfoById(parent.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getChildren())
+                    .extracting(Student::getId)
+                    .containsExactly(child.getId());
+            assertThat(found.get().getChildren())
+                    .extracting(s -> s.getUser().getUsername())
+                    .containsExactly("child1");
+        }
+    }
+
+    @Nested
+    @DisplayName("softDelete")
+    class SoftDelete {
+
+        @Test
+        @DisplayName("исключает удалённого родителя из выборок")
+        void success() {
+            Parent parent = persistParent("parent1");
+
+            parentRepository.deleteById(parent.getId());
+            clearAndFlush();
+
+            assertThat(parentRepository.findById(parent.getId())).isNotPresent();
+            assertThat(parentRepository.findWithUserById(parent.getId())).isNotPresent();
+        }
+    }
+
+}

--- a/backend/user-service/src/test/java/com/rusobr/user/jpaIT/StudentRepositoryIT.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/jpaIT/StudentRepositoryIT.java
@@ -1,0 +1,203 @@
+package com.rusobr.user.jpaIT;
+
+import com.rusobr.user.domain.model.Parent;
+import com.rusobr.user.domain.model.Student;
+import com.rusobr.user.domain.model.User;
+import com.rusobr.user.infrastructure.persistence.repository.StudentRepository;
+import com.rusobr.user.infrastructure.persistence.repository.projection.UserProjection;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StudentRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    StudentRepository studentRepository;
+
+    private Student persistStudent(String username, String firstName, String lastName) {
+        User user = persist(TestData.user(username, firstName, lastName));
+        return persist(TestData.student(user, "math"));
+    }
+
+
+    @Nested
+    @DisplayName("findAllStudentsByIds")
+    class FindAllStudentsByIds {
+
+        @Test
+        @DisplayName("возвращает студентов по id, отсортированных по фамилии")
+        void success() {
+            persistStudent("sidorov", "Алексей", "Сидоров");
+            persistStudent("ivanov", "Иван", "Иванов");
+            Student petrov = persistStudent("petrov", "Пётр", "Петров");
+
+            List<UserProjection> students = studentRepository.findAllStudentsByIds(List.of(petrov.getId()));
+
+            assertThat(students)
+                    .extracting(UserProjection::getLastName)
+                    .containsExactly("Петров");
+        }
+
+        @Test
+        @DisplayName("возвращает пустой список, если ни один id не найден")
+        void notFound() {
+            List<UserProjection> students = studentRepository.findAllStudentsByIds(List.of(999L));
+
+            assertThat(students).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllStudentsExcludeAssigned")
+    class FindAllStudentsExcludeAssigned {
+
+        @Test
+        @DisplayName("исключает студентов с переданными user id")
+        void success() {
+            Student ivanov = persistStudent("ivanov", "Иван", "Иванов");
+            Student sidorov = persistStudent("sidorov", "Алексей", "Сидоров");
+            Student petrov = persistStudent("petrov", "Пётр", "Петров");
+
+            List<UserProjection> students = studentRepository
+                    .findAllStudentsExcludeAssigned(List.of(ivanov.getUser().getId(), sidorov.getUser().getId()));
+
+            assertThat(students)
+                    .extracting(UserProjection::getLastName)
+                    .containsExactly("Петров");
+        }
+
+        @Test
+        @DisplayName("возвращает всех студентов, если список исключений пуст")
+        void emptyExcludeList() {
+            Student ivanov = persistStudent("ivanov", "Иван", "Иванов");
+            persistStudent("petrov", "Пётр", "Петров");
+
+            List<UserProjection> students = studentRepository.findAllStudentsExcludeAssigned(List.of());
+
+            assertThat(students)
+                    .extracting(UserProjection::getLastName)
+                    .containsExactly("Иванов", "Петров");
+        }
+    }
+
+    @Nested
+    @DisplayName("findWithUserAllStudents")
+    class FindWithUserAllStudents {
+
+        @Test
+        @DisplayName("возвращает всех студентов с данными пользователя, отсортированных по фамилии")
+        void success() {
+            persistStudent("sidorov", "Алексей", "Сидоров");
+            persistStudent("ivanov", "Иван", "Иванов");
+
+            List<UserProjection> students = studentRepository.findWithUserAllStudents();
+
+            assertThat(students)
+                    .extracting(UserProjection::getLastName)
+                    .containsExactly("Иванов", "Сидоров");
+        }
+    }
+
+    @Nested
+    @DisplayName("findWithUserById")
+    class FindWithUserById {
+
+        @Test
+        @DisplayName("возвращает студента вместе с пользователем")
+        void success() {
+            Student student = persistStudent("ivanov", "Иван", "Иванов");
+
+            Optional<Student> found = studentRepository.findWithUserById(student.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getUser().getUsername()).isEqualTo("ivanov");
+            assertThat(found.get().getStudyProfile()).isEqualTo("math");
+        }
+
+        @Test
+        @DisplayName("возвращает пустой Optional, если студент не найден")
+        void notFound() {
+            Optional<Student> found = studentRepository.findWithUserById(999L);
+
+            assertThat(found).isNotPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("findStudentInfoById")
+    class FindStudentInfoById {
+
+        @Test
+        @DisplayName("возвращает студента вместе с пользователем и родителем")
+        void success() {
+            Parent parent = persist(TestData.parent(persist(TestData.user("parent1", "Ольга", "Сидорова"))));
+            User childUser = persist(TestData.user("child1", "Иван", "Сидоров"));
+            Student student = persist(TestData.student(childUser, "math", parent));
+
+            Optional<Student> found = studentRepository.findStudentInfoById(student.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getUser().getUsername()).isEqualTo("child1");
+            assertThat(found.get().getParent().getUser().getUsername()).isEqualTo("parent1");
+        }
+
+        @Test
+        @DisplayName("возвращает студента с пользователем, даже если родитель не назначен")
+        void withoutParent() {
+            Student student = persistStudent("ivanov", "Иван", "Иванов");
+
+            Optional<Student> found = studentRepository.findStudentInfoById(student.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getUser().getUsername()).isEqualTo("ivanov");
+            assertThat(found.get().getParent()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdWithDeleted")
+    class FindByIdWithDeleted {
+
+        @Test
+        @DisplayName("возвращает студента, даже если он мягко удалён")
+        void success() {
+            Student student = persistStudent("ivanov", "Иван", "Иванов");
+
+            studentRepository.deleteById(student.getId());
+            clearAndFlush();
+
+            Optional<Student> withDeleted = studentRepository.findByIdWithDeleted(student.getId());
+
+            assertThat(withDeleted).isPresent();
+            assertThat(withDeleted.get().getDeletedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("softDelete")
+    class SoftDelete {
+
+        @Test
+        @DisplayName("исключает удалённого студента из выборок")
+        void success() {
+            Student student = persistStudent("ivanov", "Иван", "Иванов");
+            persistStudent("petrov", "Пётр", "Петров");
+
+            studentRepository.deleteById(student.getId());
+            clearAndFlush();
+
+            assertThat(studentRepository.findById(student.getId())).isNotPresent();
+            assertThat(studentRepository.findWithUserById(student.getId())).isNotPresent();
+            assertThat(studentRepository.findWithUserAllStudents())
+                    .extracting(UserProjection::getLastName)
+                    .containsExactly("Петров");
+        }
+    }
+
+}

--- a/backend/user-service/src/test/java/com/rusobr/user/jpaIT/TeacherRepositoryIT.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/jpaIT/TeacherRepositoryIT.java
@@ -1,0 +1,136 @@
+package com.rusobr.user.jpaIT;
+
+import com.rusobr.user.domain.model.Teacher;
+import com.rusobr.user.domain.model.User;
+import com.rusobr.user.infrastructure.persistence.repository.TeacherRepository;
+import com.rusobr.user.infrastructure.persistence.repository.projection.UserProjection;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TeacherRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    TeacherRepository teacherRepository;
+
+    private Teacher persistTeacher(String username, String firstName, String lastName) {
+        User user = persist(TestData.user(username, firstName, lastName));
+        return persist(TestData.teacher(user, username + "@mail.ru", "+79990001122"));
+    }
+
+    @Nested
+    @DisplayName("findWithUserById")
+    class FindWithUserById {
+
+        @Test
+        @DisplayName("возвращает учителя вместе с пользователем")
+        void success() {
+            Teacher teacher = persistTeacher("ivanova", "Ирина", "Иванова");
+
+            Optional<Teacher> found = teacherRepository.findWithUserById(teacher.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getUser().getUsername()).isEqualTo("ivanova");
+            assertThat(found.get().getEmail()).isEqualTo("ivanova@mail.ru");
+        }
+
+        @Test
+        @DisplayName("возвращает пустой Optional, если учитель не найден")
+        void notFound() {
+            Optional<Teacher> found = teacherRepository.findWithUserById(999L);
+
+            assertThat(found).isNotPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdWithDeleted")
+    class FindByIdWithDeleted {
+
+        @Test
+        @DisplayName("возвращает учителя, даже если он мягко удалён")
+        void success() {
+            Teacher teacher = persistTeacher("ivanova", "Ирина", "Иванова");
+
+            teacherRepository.deleteById(teacher.getId());
+            clearAndFlush();
+
+            Optional<Teacher> withDeleted = teacherRepository.findByIdWithDeleted(teacher.getId());
+
+            assertThat(withDeleted).isPresent();
+            assertThat(withDeleted.get().getDeletedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllTeachersByIds")
+    class FindAllTeachersByIds {
+
+        @Test
+        @DisplayName("возвращает учителей по id, отсортированных по фамилии")
+        void success() {
+            persistTeacher("sidorova", "Анна", "Сидорова");
+            persistTeacher("ivanova", "Ирина", "Иванова");
+            Teacher kozlova = persistTeacher("kozlova", "Ольга", "Козлова");
+
+            List<UserProjection> teachers = teacherRepository.findAllTeachersByIds(List.of(kozlova.getId()));
+
+            assertThat(teachers)
+                    .extracting(UserProjection::getLastName)
+                    .containsExactly("Козлова");
+        }
+
+        @Test
+        @DisplayName("возвращает пустой список, если ни один id не найден")
+        void notFound() {
+            List<UserProjection> teachers = teacherRepository.findAllTeachersByIds(List.of(999L));
+
+            assertThat(teachers).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getTeacherSimpleById")
+    class GetTeacherSimpleById {
+
+        @Test
+        @DisplayName("возвращает проекцию учителя по id")
+        void success() {
+            Teacher teacher = persistTeacher("ivanova", "Ирина", "Иванова");
+
+            UserProjection projection = teacherRepository.getTeacherSimpleById(teacher.getId());
+
+            assertThat(projection).isNotNull();
+            assertThat(projection.getId()).isEqualTo(teacher.getId());
+            assertThat(projection.getFirstName()).isEqualTo("Ирина");
+            assertThat(projection.getLastName()).isEqualTo("Иванова");
+            assertThat(projection.getUsername()).isEqualTo("ivanova");
+        }
+    }
+
+    @Nested
+    @DisplayName("softDelete")
+    class SoftDelete {
+
+        @Test
+        @DisplayName("исключает удалённого учителя из выборок")
+        void success() {
+            Teacher teacher = persistTeacher("ivanova", "Ирина", "Иванова");
+            persistTeacher("kozova", "Ольга", "Козлова");
+
+            teacherRepository.deleteById(teacher.getId());
+            clearAndFlush();
+
+            assertThat(teacherRepository.findById(teacher.getId())).isNotPresent();
+            assertThat(teacherRepository.findWithUserById(teacher.getId())).isNotPresent();
+            assertThat(teacherRepository.findAllTeachersByIds(List.of(teacher.getId()))).isEmpty();
+        }
+    }
+
+}

--- a/backend/user-service/src/test/java/com/rusobr/user/jpaIT/TestData.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/jpaIT/TestData.java
@@ -1,0 +1,73 @@
+package com.rusobr.user.jpaIT;
+
+import com.rusobr.common.enums.UserRole;
+import com.rusobr.user.domain.model.Parent;
+import com.rusobr.user.domain.model.Student;
+import com.rusobr.user.domain.model.Teacher;
+import com.rusobr.user.domain.model.User;
+
+import java.util.ArrayList;
+import java.util.Set;
+
+public final class TestData {
+
+    private TestData() {
+    }
+
+    public static User user(String username, String firstName, String lastName) {
+        return User.builder()
+                .username(username)
+                .firstName(firstName)
+                .lastName(lastName)
+                .build();
+    }
+
+    public static User user(String username, String firstName, String lastName, Set<UserRole> roles) {
+        return User.builder()
+                .username(username)
+                .firstName(firstName)
+                .lastName(lastName)
+                .roles(roles)
+                .build();
+    }
+
+    public static User user(String username, String firstName, String lastName, String keycloakId) {
+        return User.builder()
+                .username(username)
+                .firstName(firstName)
+                .lastName(lastName)
+                .keycloakId(keycloakId)
+                .build();
+    }
+
+    public static Student student(User user, String studyProfile) {
+        return Student.builder()
+                .user(user)
+                .studyProfile(studyProfile)
+                .build();
+    }
+
+    public static Student student(User user, String studyProfile, Parent parent) {
+        return Student.builder()
+                .user(user)
+                .studyProfile(studyProfile)
+                .parent(parent)
+                .build();
+    }
+
+    public static Teacher teacher(User user, String email, String phoneNumber) {
+        return Teacher.builder()
+                .user(user)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+
+    public static Parent parent(User user) {
+        return Parent.builder()
+                .user(user)
+                .children(new ArrayList<>())
+                .build();
+    }
+
+}

--- a/backend/user-service/src/test/java/com/rusobr/user/jpaIT/UserRepositoryIT.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/jpaIT/UserRepositoryIT.java
@@ -1,0 +1,233 @@
+package com.rusobr.user.jpaIT;
+
+import com.rusobr.common.enums.UserRole;
+import com.rusobr.user.domain.model.User;
+import com.rusobr.user.infrastructure.persistence.repository.UserRepository;
+import com.rusobr.user.infrastructure.specification.UserSpecification;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserRepositoryIT extends AbstractRepositoryIT {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Nested
+    @DisplayName("findByKeycloakId")
+    class FindByKeycloakId {
+
+        @Test
+        @DisplayName("возвращает пользователя по keycloak id")
+        void success() {
+            persist(TestData.user("ivan", "Иван", "Иванов", "kc-123"));
+
+            Optional<User> found = userRepository.findByKeycloakId("kc-123");
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getUsername()).isEqualTo("ivan");
+        }
+
+        @Test
+        @DisplayName("возвращает пустой Optional, если пользователь не найден")
+        void notFound() {
+            Optional<User> found = userRepository.findByKeycloakId("missing");
+
+            assertThat(found).isNotPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByUsername")
+    class ExistsByUsername {
+
+        @Test
+        @DisplayName("возвращает true, если username занят")
+        void taken() {
+            persist(TestData.user("ivan", "Иван", "Иванов"));
+
+            boolean exists = userRepository.existsByUsername("ivan");
+
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        @DisplayName("возвращает false, если username свободен")
+        void free() {
+            persist(TestData.user("ivan", "Иван", "Иванов"));
+
+            boolean exists = userRepository.existsByUsername("petr");
+
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByUsernameAndIdNot")
+    class ExistsByUsernameAndIdNot {
+
+        @Test
+        @DisplayName("возвращает true, если username занят другим пользователем")
+        void takenByOther() {
+            User ivan = persist(TestData.user("ivan", "Иван", "Иванов"));
+            persist(TestData.user("petr", "Пётр", "Петров"));
+
+            boolean exists = userRepository.existsByUsernameAndIdNot("petr", ivan.getId());
+
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        @DisplayName("возвращает false, если username занят тем же пользователем")
+        void takenBySame() {
+            User ivan = persist(TestData.user("ivan", "Иван", "Иванов"));
+
+            boolean exists = userRepository.existsByUsernameAndIdNot("ivan", ivan.getId());
+
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByUsername")
+    class FindByUsername {
+
+        @Test
+        @DisplayName("возвращает пользователя по username")
+        void success() {
+            persist(TestData.user("ivan", "Иван", "Иванов"));
+
+            Optional<User> found = userRepository.findByUsername("ivan");
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getFirstName()).isEqualTo("Иван");
+        }
+
+        @Test
+        @DisplayName("возвращает пустой Optional, если пользователь не найден")
+        void notFound() {
+            Optional<User> found = userRepository.findByUsername("petr");
+
+            assertThat(found).isNotPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("findWithRolesById")
+    class FindWithRolesById {
+
+        @Test
+        @DisplayName("возвращает пользователя с ролями")
+        void success() {
+            User user = persist(TestData.user("ivan", "Иван", "Иванов", Set.of(UserRole.STUDENT, UserRole.PARENT)));
+
+            Optional<User> found = userRepository.findWithRolesById(user.getId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getRoles())
+                    .containsExactlyInAnyOrder(UserRole.STUDENT, UserRole.PARENT);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAll")
+    class FindAll {
+
+        @Test
+        @DisplayName("фильтрует пользователей по роли")
+        void byRole() {
+            persist(TestData.user("teacher1", "Анна", "Иванова", Set.of(UserRole.TEACHER)));
+            persist(TestData.user("student1", "Иван", "Петров", Set.of(UserRole.STUDENT)));
+
+            Specification<User> specification = UserSpecification.findByRole(UserRole.STUDENT)
+                    .and(UserSpecification.findByFullNameFuzzy(null));
+
+            Page<User> page = userRepository.findAll(specification, PageRequest.of(0, 10));
+
+            assertThat(page.getContent())
+                    .extracting(User::getUsername)
+                    .containsExactly("student1");
+        }
+
+        @Test
+        @DisplayName("фильтрует пользователей по части ФИО")
+        void byFullName() {
+            persist(TestData.user("ivanov", "Иван", "Иванов"));
+            persist(TestData.user("petrov", "Пётр", "Петров"));
+
+            Specification<User> specification = UserSpecification.findByRole(null)
+                    .and(UserSpecification.findByFullNameFuzzy("Иван"));
+
+            Page<User> page = userRepository.findAll(specification, PageRequest.of(0, 10));
+
+            assertThat(page.getContent())
+                    .extracting(User::getUsername)
+                    .containsExactly("ivanov");
+        }
+
+        @Test
+        @DisplayName("комбинирует фильтры по роли и ФИО")
+        void byRoleAndFullName() {
+            persist(TestData.user("student1", "Иван", "Петров", Set.of(UserRole.STUDENT)));
+            persist(TestData.user("teacher1", "Иван", "Сидоров", Set.of(UserRole.TEACHER)));
+
+            Specification<User> specification = UserSpecification.findByRole(UserRole.STUDENT)
+                    .and(UserSpecification.findByFullNameFuzzy("Иван"));
+
+            Page<User> page = userRepository.findAll(specification, PageRequest.of(0, 10));
+
+            assertThat(page.getContent())
+                    .extracting(User::getUsername)
+                    .containsExactly("student1");
+        }
+    }
+
+    @Nested
+    @DisplayName("setKeycloakId")
+    class SetKeycloakId {
+
+        @Test
+        @DisplayName("обновляет keycloakId пользователя")
+        void success() {
+            User user = persist(TestData.user("ivan", "Иван", "Иванов"));
+
+            userRepository.setKeycloakId("kc-456", user.getId());
+            clearAndFlush();
+
+            Optional<User> found = userRepository.findByKeycloakId("kc-456");
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getId()).isEqualTo(user.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("softDelete")
+    class SoftDelete {
+
+        @Test
+        @DisplayName("исключает удалённого пользователя из выборок")
+        void success() {
+            User user = persist(TestData.user("ivan", "Иван", "Иванов"));
+
+            userRepository.deleteById(user.getId());
+            clearAndFlush();
+
+            assertThat(userRepository.findById(user.getId())).isNotPresent();
+            assertThat(userRepository.findByUsername("ivan")).isNotPresent();
+            assertThat(userRepository.existsByUsername("ivan")).isFalse();
+            assertThat(userRepository.findAll()).isEmpty();
+        }
+    }
+
+}


### PR DESCRIPTION
### Использовал статический инициализатор `AbstractRepositoryIT` что бы не создавать новый контейнер каждый вызов

## academic-service

### `AcademicYearRepositoryIT`
- **`findAllByOrderByStartDateDesc`** — возвращает учебные годы от новых к старым

### `AcademicPeriodRepositoryIT`
- **`findByDate`** — возвращает период, содержащий дату; возвращает пусто, если дата вне всех периодов
- **`findAllOrderAsc`** — загружает учебный год и сортирует периоды по дате начала
- **`findWithAcademicYearById`** — загружает учебный год периода
- **`findAllByAcademicYearIdOrderByStartDateAsc`** — возвращает только периоды указанного года в порядке возрастания
- **`getAcademicPeriodsByAcademicYearId`** — возвращает периоды учебного года
- **`existsByName`** — проверяет наличие периода с указанным именем

### `AttendanceRepositoryIT`
- **`findByStudentIdAndLessonInstanceId`** — находит посещаемость ученика на уроке; возвращает пусто, если посещаемость отсутствует
- **`isAttendanceOwnedByTeacher`** — `true` для учителя предмета и `false` для другого
- **`findWithLessonInstanceById`** — загружает урок посещаемости

### `ClassStudentRepositoryIT`
- **`existsByStudentId`** — `true`, если ученик состоит в классе
- **`findBySchoolClassIdAndStudentId`** — находит запись ученика в классе
- **`findAllStudentIds`** — собирает id всех учеников по классам

### `FinalGradeRepositoryIT`
- **`findFinalGradesByStudentId`** — возвращает итоговые оценки ученика за год, отсортированные по предмету
- **`findFinalGradesByTeachingAssignmentId`** — возвращает оценки по назначению за указанный год
- **`findWithAcademicYearById`** — загружает учебный год оценки
- **`isFinalGradeOwnedByTeacher`** — `true` для учителя предмета и `false` для другого

### `GradeRepositoryIT`
- **`getClassGrades`** — возвращает оценки назначения, отсортированные по ученику
- **`getAverageGrade`** — вычисляет средневзвешенный балл; возвращает 0, если оценок в диапазоне нет
- **`findAllByDateAndStudentId`** — возвращает оценки ученика за дату с названием предмета
- **`findAverageStudentsByTeachingAssignment`** — группирует средний балл по ученикам
- **`findDetailById`** — возвращает детали оценки с учителем
- **`existsByIdAndStudentId`** — проверяет принадлежность оценки ученику
- **`isGradeOwnedByTeacher`** — `true` для учителя предмета и `false` для другого
- **`findWithLessonInstanceById`** — загружает урок оценки

### `HomeworkRepositoryIT`
- **`findHomeworksByDate`** — возвращает домашние задания ученика за дату; возвращает пусто для другой даты или ученика
- **`findHomeworksByTeachingAssignmentId`** — возвращает домашние задания назначения постранично
- **`findWithLessonInstanceById`** — загружает урок домашнего задания
- **`isHomeworkOwnedByTeacher`** — `true` для учителя предмета и `false` для другого

### `LessonInstanceRepositoryIT`
- **`findDiaryLessonsByStudentIdAndDateRange`** — возвращает уроки ученика за диапазон дат с оценками
- **`findGradesLessonsByStudentId`** — возвращает журнал оценок ученика
- **`findLessonDatesByStudentId`** — возвращает уникальные даты уроков ученика
- **`findLessonInstanceByTeachingAssignmentId`** — возвращает проекции уроков назначения
- **`findGradesByTeachingAssignment`** — возвращает оценки по назначению
- **`findAttendancesByTeachingAssignment`** — возвращает посещаемость по назначению
- **`softDeleteFutureEmptyAfterDate`** — удаляет только пустые будущие уроки
- **`existsByScheduleLessonAndLessonDate`** — проверяет уникальность урока на дату
- **`findLessonInstancesByScheduleId`** — возвращает уроки по идентификаторам расписаний
- **`findLessonInstanceGradesByPeriodAndStudent`** — уроки с оценками только для указанного ученика
- **`findLessonInstanceAttendancesByPeriodAndStudent`** — уроки с посещаемостью только для указанного ученика
- **`findLessonInstanceHomeworksByPeriodAndStudent`** — уроки с домашними заданиями (left join)
- **`isOwnedByTeacherAndHasStudent`** — проверяет принадлежность урока учителю и ученику
- **`isOwnedByTeacher`** — проверяет принадлежность урока учителю

### `PeriodGradeRepositoryIT`
- **`findWithAcademicPeriodById`** — загружает учебный период оценки
- **`findPeriodGradeByStudentId`** — возвращает оценки ученика, отсортированные по периоду и предмету
- **`findPeriodGradesByTeachingAssignmentId`** — фильтрует оценки по назначению и году
- **`isPeriodGradeOwnedByTeacher`** — `true` для учителя предмета и `false` для другого

### `ScheduleLessonRepositoryIT`
- **`getScheduleByDate`** — возвращает активные уроки расписания на день; исключает устаревшие уроки и уроки других дней
- **`findAllByStudentId`** — возвращает все уроки класса ученика
- **`findByTeachingAssignmentId`** — фильтрует уроки по назначению
- **`findClassSchedule`** — возвращает активные отсортированные уроки класса
- **`findWithTeachingAssignmentById`** — загружает назначение урока
- **`existsActiveByClassSlot`** — проверяет занятость слота класса
- **`existsActiveByTeachingAssignmentSlot`** — проверяет занятость слота назначения
- **`findAllByClassIdAndPeriod`** — возвращает уроки класса, пересекающие период
- **`existsByTeacherSlot`** — проверяет занятость учителя в слоте
- **`findDiaryScheduleByStudentId`** — возвращает уроки ученика, пересекающие период
- **`findTeacherScheduleByDate`** — возвращает экземпляры уроков учителя на дату
- **`findTeacherScheduleByPeriod`** — возвращает экземпляры уроков учителя за период

### `SchoolClassRepositoryIT`
- **`findStudentIdsFromSchoolClasses`** — возвращает id учеников класса
- **`findSchoolClassByStudentId`** — находит класс ученика
- **`findStudentsIdsByTeachingAssignment`** — возвращает id учеников по назначению
- **`findAllByAcademicYearIdOrderByNameAsc`** — фильтрует по году и сортирует по имени
- **`findAllByOrderByNameAsc`** — загружает учебный год и сортирует по имени
- **`existsByNameAndAcademicYearId`** — проверяет уникальность имени в пределах года
- **`existsByNameAndIdNot`** — игнорирует собственный id при проверке
- **`existsByNameAndAcademicYearIdAndIdNot`** — комбинирует имя, год и исключение собственного id
- **`findWithClassStudentById`** — загружает учеников класса
- **`findWithAcademicYearById`** — загружает учебный год класса
- **`findSchoolClassesBySchoolClassTeacherId`** — возвращает классы классного руководителя
- **`findSchoolClassesTeacherId`** — возвращает уникальные классы учителя

### `SubjectRepositoryIT`
- **`findAllByOrderByNameAsc`** — возвращает предметы, отсортированные по имени
- **`findById`** — возвращает предмет по id
- **`softDelete`** — исключает удалённый предмет из выборок

### `TeacherSubjectRepositoryIT`
- **`findByTeacherId`** — возвращает предметы учителя, отсортированные по имени
- **`softDelete`** — помечает запись удалённой и исключает её из активных запросов

### `TeachingAssignmentRepositoryIT`
- **`findByIdWithClassId`** — возвращает id класса назначения
- **`findTeachingAssignmentDetailByTeacherId`** — детали назначений, отсортированные по предмету и классу
- **`findBySubjectIdAndSchoolClassIdAndTeacherId`** — находит точное назначение по предмету, классу и учителю
- **`findStudentIdsByTeachingAssignmentId`** — возвращает id учеников класса назначения
- **`findByTeacherId`** — загружает предмет и класс назначения
- **`isTeacherOwnedAssignment`** — `true` для учителя назначения и `false` для другого
- **`isOwnedByTeacherWithStudent`** — проверяет принадлежность назначения учителю и ученику

---

## user-service

### `UserRepositoryIT`
- **`findByKeycloakId`**, **`findByUsername`** — успех и not found
- **`existsByUsername`**, **`existsByUsernameAndIdNot`** — занят/свободен
- **`findWithRolesById`** — роли загружаются entity graph-ом
- **`findAll(spec, pageable)`** через `UserSpecification` — фильтр по роли, по части ФИО (`%Иван%`), комбинация обоих
- **`setKeycloakId`** — bulk-обновление (`@Modifying`)
- **`softDelete`** — после `deleteById` юзер исчезает из `findById`, `findByUsername`, `existsByUsername`, `findAll`

### `StudentRepositoryIT`
- **`findAllStudentsByIds`**, **`findWithUserAllStudents`** — проекции, сортировка по фамилии
- **`findAllStudentsExcludeAssigned`** — исключение по user id, пустой список исключений
- **`findWithUserById`**, **`findStudentInfoById`** — загрузка user и parent
- **`findByIdWithDeleted`** — native-запрос возвращает мягко удалённого студента с `deletedAt`
- **`softDelete`** — студент пропадает из выборок

### `TeacherRepositoryIT`
- **`findWithUserById`**, **`getTeacherSimpleById`**, **`findAllTeachersByIds`**
- **`findByIdWithDeleted`**, **`softDelete`**

### `ParentRepositoryIT`
- **`findWithUserById`** — с детьми и без детей
- **`findParentInfoById`** — дети с их пользователями
- **`findByIdWithDeleted`**, **`softDelete`**

---

*Closes #138*