### PR TITLE
test(security): Интеграционные security тесты для academic/user сервисов

### DIFF
--- a/backend/academic-service/build.gradle
+++ b/backend/academic-service/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.10'
     implementation 'com.openhtmltopdf:openhtmltopdf-svg-support:1.0.10'
 
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mockito:mockito-core'

--- a/backend/academic-service/src/main/java/com/rusobr/academic/config/security/SecurityConfig.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/config/security/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
                 .cors(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(req -> {
                     req
-                            .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll().requestMatchers("/public/**", "/actuator/**").permitAll()
+                            .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll().requestMatchers("/public/**", "/actuator/**",
+                                    "/v3/api-docs/**", "/swagger-ui/**").permitAll()
                             .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                             .requestMatchers(GET, "/api/v1/academic-years").hasAnyRole(STUDENT.name(), TEACHER.name(), PARENT.name(), ADMIN.name())
                             .requestMatchers(GET, "/api/v1/academic-periods").hasAnyRole(STUDENT.name(), TEACHER.name(), PARENT.name(), ADMIN.name())

--- a/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/GradeController.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/web/controller/GradeController.java
@@ -20,11 +20,6 @@ public class GradeController {
 
     private final GradeService gradeService;
 
-    @GetMapping("/{id}")
-    public GradeResponse getById(@PathVariable Long id) {
-        return gradeService.getById(id);
-    }
-
     @PreAuthorize("@gradeSecurity.canViewStudent(#id, authentication)")
     @GetMapping("/{id}/detail")
     public GradeDetailResponse getDetailById(@PathVariable Long id) {

--- a/backend/academic-service/src/test/java/com/rusobr/academic/controller/GradeControllerTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/controller/GradeControllerTest.java
@@ -62,30 +62,6 @@ public class GradeControllerTest {
     }
 
     @Test
-    @DisplayName("GET /grades/{id} — 200 and grade details")
-    void getById_ShouldReturn200() throws Exception {
-        when(gradeService.getById(GRADE_ID)).thenReturn(buildGradeResponse());
-
-        mockMvc.perform(get("/api/v1/grades/{id}", GRADE_ID))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(GRADE_ID))
-                .andExpect(jsonPath("$.studentId").value(STUDENT_ID))
-                .andExpect(jsonPath("$.value").value(5))
-                .andExpect(jsonPath("$.weight").value(2))
-                .andExpect(jsonPath("$.type").value("TEST"));
-    }
-
-    @Test
-    @DisplayName("GET /grades/{id} — 404 when grade not found")
-    void getById_ShouldReturn404_WhenNotFound() throws Exception {
-        when(gradeService.getById(GRADE_ID)).thenThrow(new NotFoundException("Grade with id " + GRADE_ID + " not found", AcademicExceptionCode.GRADE_NOT_FOUND));
-
-        mockMvc.perform(get("/api/v1/grades/{id}", GRADE_ID))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("Grade with id " + GRADE_ID + " not found"));
-    }
-
-    @Test
     @DisplayName("POST /grades — 201 and created grade")
     void create_ShouldReturn201() throws Exception {
         CreateGradeRequest request = buildCreateRequest();

--- a/backend/academic-service/src/test/java/com/rusobr/academic/securityIT/AbstractSecurityIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/securityIT/AbstractSecurityIT.java
@@ -1,0 +1,32 @@
+package com.rusobr.academic.securityIT;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@SpringBootTest(properties = {
+        "eureka.client.enabled=false",
+        "spring.cloud.discovery.enabled=false"
+})
+@AutoConfigureMockMvc
+@Import(SecurityITConfiguration.class)
+public abstract class AbstractSecurityIT {
+
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    static {
+        POSTGRES.start();
+    }
+
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/securityIT/JwtTestUtils.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/securityIT/JwtTestUtils.java
@@ -1,0 +1,92 @@
+package com.rusobr.academic.securityIT;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class JwtTestUtils {
+
+    public static final String ISSUER = "http://localhost:9090/realms/dnevnik-realm";
+
+    private static final KeyPair KEY_PAIR = generateKeyPair();
+    private static final RSAKey RSA_KEY = new RSAKey.Builder((RSAPublicKey) KEY_PAIR.getPublic())
+            .privateKey(KEY_PAIR.getPrivate())
+            .build();
+    private static final RSAPublicKey PUBLIC_KEY = (RSAPublicKey) KEY_PAIR.getPublic();
+    private static final JWKSource<SecurityContext> JWK_SOURCE =
+            new ImmutableJWKSet<>(new JWKSet(RSA_KEY));
+
+    private JwtTestUtils() {
+    }
+
+    private static KeyPair generateKeyPair() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            return generator.generateKeyPair();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate test RSA key", e);
+        }
+    }
+
+    public static RSAPublicKey publicKey() {
+        return PUBLIC_KEY;
+    }
+
+    public static String token(Long userId, List<String> roles) {
+        return token(userId, roles, Duration.ofHours(1));
+    }
+
+    public static String token(Long userId, List<String> roles, Duration validity) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("user_id", userId);
+        claims.put("realm_access", Map.of("roles", roles));
+        return token(claims, validity);
+    }
+
+    public static String token(Map<String, Object> claims, Duration validity) {
+        Instant now = Instant.now();
+        JwtClaimsSet claimsSet = JwtClaimsSet.builder()
+                .issuer(ISSUER)
+                .issuedAt(now)
+                .expiresAt(now.plus(validity))
+                .subject(String.valueOf(claims.getOrDefault("user_id", "unknown")))
+                .claims(c -> c.putAll(claims))
+                .build();
+        return sign(claimsSet);
+    }
+
+    public static String expiredToken(Long userId, List<String> roles) {
+        Instant now = Instant.now();
+        JwtClaimsSet claimsSet = JwtClaimsSet.builder()
+                .issuer(ISSUER)
+                .issuedAt(now.minus(Duration.ofHours(2)))
+                .expiresAt(now.minus(Duration.ofHours(1)))
+                .subject(String.valueOf(userId))
+                .claim("user_id", userId)
+                .claim("realm_access", Map.of("roles", roles))
+                .build();
+        return sign(claimsSet);
+    }
+
+    private static String sign(JwtClaimsSet claimsSet) {
+        return new NimbusJwtEncoder(JWK_SOURCE)
+                .encode(JwtEncoderParameters.from(claimsSet))
+                .getTokenValue();
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/securityIT/KeycloakRoleConverterTest.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/securityIT/KeycloakRoleConverterTest.java
@@ -1,0 +1,77 @@
+package com.rusobr.academic.securityIT;
+
+import com.rusobr.common.config.SecurityHelper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KeycloakRoleConverterTest {
+
+    private final Converter<Jwt, ? extends AbstractAuthenticationToken> converter =
+            SecurityHelper.keycloakRoleJwtConverter();
+
+    @Test
+    @DisplayName("realm_access.roles -> ROLE_* authorities")
+    void shouldMapRealmAccessRolesToRoleAuthorities() {
+        Jwt jwt = buildJwt(Map.of("realm_access", Map.of("roles", List.of("TEACHER", "USER"))));
+
+        AbstractAuthenticationToken token = converter.convert(jwt);
+
+        assertThat(authorities(token)).containsExactlyInAnyOrder("ROLE_TEACHER", "ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("")
+    void shouldReturnEmptyAuthoritiesWhenRealmAccessMissing() {
+        Jwt jwt = buildJwt(Map.of("sub", "user-id-123"));
+
+        AbstractAuthenticationToken token = converter.convert(jwt);
+
+        assertThat(authorities(token)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Нестроковые значения ролей отсеиваются")
+    void shouldIgnoreNonStringRoles() {
+        Jwt jwt = buildJwt(Map.of("realm_access", Map.of("roles", List.of("TEACHER", 123, true))));
+
+        AbstractAuthenticationToken token = converter.convert(jwt);
+
+        assertThat(authorities(token)).containsExactly("ROLE_TEACHER");
+    }
+
+    @Test
+    @DisplayName("resource_access.account не попадает в authorities")
+    void shouldNotMapResourceAccessAccountRoles() {
+        Jwt jwt = buildJwt(Map.of(
+                "realm_access", Map.of("roles", List.of("STUDENT")),
+                "resource_access", Map.of("account", Map.of("roles", List.of("manage-account")))));
+
+        AbstractAuthenticationToken token = converter.convert(jwt);
+
+        assertThat(authorities(token)).containsExactly("ROLE_STUDENT");
+    }
+
+    private Collection<String> authorities(AbstractAuthenticationToken token) {
+        return token.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+    }
+
+    private Jwt buildJwt(Map<String, Object> claims) {
+        return Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .claims(c -> c.putAll(claims))
+                .build();
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/securityIT/OwnershipSecurityIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/securityIT/OwnershipSecurityIT.java
@@ -1,0 +1,163 @@
+package com.rusobr.academic.securityIT;
+
+import com.rusobr.academic.domain.enums.GradeType;
+import com.rusobr.academic.domain.model.AcademicYear;
+import com.rusobr.academic.domain.model.Grade;
+import com.rusobr.academic.domain.model.LessonInstance;
+import com.rusobr.academic.domain.model.ScheduleLesson;
+import com.rusobr.academic.domain.model.SchoolClass;
+import com.rusobr.academic.domain.model.Subject;
+import com.rusobr.academic.domain.model.TeachingAssignment;
+import com.rusobr.academic.infrastructure.client.UserClient;
+import com.rusobr.academic.infrastructure.persistence.repository.AcademicYearRepository;
+import com.rusobr.academic.infrastructure.persistence.repository.GradeRepository;
+import com.rusobr.academic.infrastructure.persistence.repository.LessonInstanceRepository;
+import com.rusobr.academic.infrastructure.persistence.repository.ScheduleLessonRepository;
+import com.rusobr.academic.infrastructure.persistence.repository.SchoolClassRepository;
+import com.rusobr.academic.infrastructure.persistence.repository.SubjectRepository;
+import com.rusobr.academic.infrastructure.persistence.repository.TeachingAssignmentRepository;
+import com.rusobr.common.dto.UserFeignResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class OwnershipSecurityIT extends AbstractSecurityIT {
+
+    private static final long STUDENT_OWNER_ID = 27L;
+    private static final long STUDENT_OTHER_ID = 99L;
+    private static final long TEACHER_OWNER_ID = 10L;
+    private static final long TEACHER_OTHER_ID = 5L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private AcademicYearRepository academicYearRepository;
+    @Autowired
+    private SubjectRepository subjectRepository;
+    @Autowired
+    private SchoolClassRepository schoolClassRepository;
+    @Autowired
+    private TeachingAssignmentRepository teachingAssignmentRepository;
+    @Autowired
+    private ScheduleLessonRepository scheduleLessonRepository;
+    @Autowired
+    private LessonInstanceRepository lessonInstanceRepository;
+    @Autowired
+    private GradeRepository gradeRepository;
+
+    @MockitoBean
+    private UserClient userClient;
+
+    private long gradeId;
+    private long assignmentId;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("""
+                TRUNCATE TABLE grades, lesson_instances, schedule_lessons, teaching_assignments,
+                        school_classes, academic_years, subjects CASCADE
+                """);
+
+        AcademicYear academicYear = academicYearRepository.save(
+                AcademicYear.builder()
+                        .name("2025-2026")
+                        .description("test")
+                        .startDate(LocalDate.of(2025, 9, 1))
+                        .endDate(LocalDate.of(2026, 5, 31))
+                        .build());
+
+        Subject subject = subjectRepository.save(Subject.builder().name("Математика").build());
+
+        SchoolClass schoolClass = schoolClassRepository.save(
+                SchoolClass.builder().name("5А").academicYear(academicYear).build());
+
+        TeachingAssignment assignment = teachingAssignmentRepository.save(
+                TeachingAssignment.builder()
+                        .teacherId(TEACHER_OWNER_ID)
+                        .schoolClass(schoolClass)
+                        .subject(subject)
+                        .build());
+        assignmentId = assignment.getId();
+
+        ScheduleLesson scheduleLesson = scheduleLessonRepository.save(
+                ScheduleLesson.builder()
+                        .teachingAssignment(assignment)
+                        .dayOfWeek(DayOfWeek.MONDAY)
+                        .lessonNumber(1)
+                        .validFrom(LocalDate.of(2025, 9, 1))
+                        .build());
+
+        LessonInstance lessonInstance = lessonInstanceRepository.save(
+                LessonInstance.builder()
+                        .scheduleLesson(scheduleLesson)
+                        .lessonDate(LocalDate.of(2025, 9, 1))
+                        .build());
+
+        gradeId = gradeRepository.save(Grade.builder()
+                .studentId(STUDENT_OWNER_ID)
+                .lessonInstance(lessonInstance)
+                .value(5)
+                .weight(2)
+                .type(GradeType.TEST)
+                .build()).getId();
+
+        when(userClient.getTeacherSimpleById(any())).thenReturn(
+                UserFeignResponse.builder()
+                        .id(TEACHER_OWNER_ID)
+                        .firstName("Иван")
+                        .lastName("Учителев")
+                        .username("teacher")
+                        .build());
+    }
+
+    @Test
+    @DisplayName("Ученик видит свою оценку -> 200")
+    void student_OwnGrade_ShouldReturn200() throws Exception {
+        String studentToken = JwtTestUtils.token(STUDENT_OWNER_ID, List.of("STUDENT"));
+
+        mockMvc.perform(get("/api/v1/grades/{id}/detail", gradeId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + studentToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Ученик не видит чужую оценку -> 403")
+    void student_OtherGrade_ShouldReturn403() throws Exception {
+        String otherStudentToken = JwtTestUtils.token(STUDENT_OTHER_ID, List.of("STUDENT"));
+
+        mockMvc.perform(get("/api/v1/grades/{id}/detail", gradeId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + otherStudentToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Учитель не видит журнал чужого назначения -> 403")
+    void teacher_NotOwnedAssignment_ShouldReturn403() throws Exception {
+        String otherTeacherToken = JwtTestUtils.token(TEACHER_OTHER_ID, List.of("TEACHER"));
+
+        mockMvc.perform(get("/api/v1/journal/by-assignment")
+                        .param("teachingAssignmentId", String.valueOf(assignmentId))
+                        .param("academicPeriodId", "1")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + otherTeacherToken))
+                .andExpect(status().isForbidden());
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/securityIT/ResourceServerSecurityIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/securityIT/ResourceServerSecurityIT.java
@@ -1,0 +1,114 @@
+package com.rusobr.academic.securityIT;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ResourceServerSecurityIT extends AbstractSecurityIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Запрос без токена -> 401")
+    void noToken_ShouldReturn401() throws Exception {
+        mockMvc.perform(get("/api/v1/academic-years"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Битый токен -> 401")
+    void invalidToken_ShouldReturn401() throws Exception {
+        mockMvc.perform(get("/api/v1/academic-years")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer not-a-valid-jwt"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Подписанный, но просроченный токен -> 401")
+    void expiredToken_ShouldReturn401() throws Exception {
+        String expiredToken = JwtTestUtils.expiredToken(27L, List.of("STUDENT"));
+
+        mockMvc.perform(get("/api/v1/academic-years")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + expiredToken))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Валидный токен с нужной ролью -> 200")
+    void validTokenWithRequiredRole_ShouldReturn200() throws Exception {
+        String studentToken = JwtTestUtils.token(27L, List.of("STUDENT"));
+
+        mockMvc.perform(get("/api/v1/academic-years")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + studentToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Валидный токен, но недостаточная роль -> 403")
+    void validTokenWithInsufficientRole_ShouldReturn403() throws Exception {
+        String studentToken = JwtTestUtils.token(27L, List.of("STUDENT"));
+
+        mockMvc.perform(get("/api/v1/subjects")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + studentToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Валидный токен без ролей -> 403")
+    void validTokenWithoutRoles_ShouldReturn403() throws Exception {
+        String noRolesToken = JwtTestUtils.token(Map.of("user_id", 27L), Duration.ofHours(1));
+
+        mockMvc.perform(get("/api/v1/academic-years")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + noRolesToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Публичный actuator/health без токена -> 200")
+    void publicActuatorHealth_WithoutToken_ShouldReturn200() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Публичный /public/** не блокируется security (не 401/403)")
+    void publicPath_WithoutToken_IsNotBlockedBySecurity() throws Exception {
+        MvcResult result = mockMvc.perform(get("/public/nonexistent"))
+                .andReturn();
+
+        assertThat(result.getResponse().getStatus())
+                .as("public path must not be blocked by security")
+                .isNotIn(HttpStatus.UNAUTHORIZED.value(), HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    @DisplayName("Незамапленный URL без токена -> 401")
+    void unmappedUrl_WithoutToken_ShouldReturn401() throws Exception {
+        mockMvc.perform(get("/api/v1/nonexistent-endpoint"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Незамапленный URL с валидным токеном -> 403 (anyRequest.denyAll)")
+    void unmappedUrl_WithToken_ShouldReturn403() throws Exception {
+        String studentToken = JwtTestUtils.token(27L, List.of("STUDENT"));
+
+        mockMvc.perform(get("/api/v1/nonexistent-endpoint")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + studentToken))
+                .andExpect(status().isForbidden());
+    }
+
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/securityIT/SecurityITConfiguration.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/securityIT/SecurityITConfiguration.java
@@ -1,0 +1,16 @@
+package com.rusobr.academic.securityIT;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+@TestConfiguration
+public class SecurityITConfiguration {
+
+    @Bean
+    JwtDecoder jwtDecoder() {
+        return NimbusJwtDecoder.withPublicKey(JwtTestUtils.publicKey()).build();
+    }
+
+}

--- a/backend/api-gateway/src/main/java/com/rusobr/gateway/infrastructure/security/SecurityConfig.java
+++ b/backend/api-gateway/src/main/java/com/rusobr/gateway/infrastructure/security/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
                         .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .pathMatchers("/user-service/v3/api-docs/**", "/swagger-ui/**").permitAll()
                         .pathMatchers("/academic-service/v3/api-docs/**", "/swagger-ui/**").permitAll()
-                        .pathMatchers("/actuator/**").permitAll()
+                        .pathMatchers("/actuator/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyExchange().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> {}))
                 .build();

--- a/backend/common/src/main/java/com/rusobr/common/config/SecurityHelper.java
+++ b/backend/common/src/main/java/com/rusobr/common/config/SecurityHelper.java
@@ -21,7 +21,10 @@ public class SecurityHelper {
                     .map(m -> m.get("roles"))
                     .filter(List.class::isInstance)
                     .map(roles -> (List<?>) roles)
-                    .ifPresent(roles -> roles.forEach(r ->
+                    .ifPresent(roles -> roles.stream()
+                            .filter(String.class::isInstance)
+                            .map(String.class::cast)
+                            .forEach(r ->
                             authorities.add(new SimpleGrantedAuthority("ROLE_" + r))));
 
             return new JwtAuthenticationToken(jwt, authorities);

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     implementation 'io.micrometer:context-propagation'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
-
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 

--- a/backend/user-service/src/main/java/com/rusobr/user/config/SecurityConfig.java
+++ b/backend/user-service/src/main/java/com/rusobr/user/config/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig {
                 .cors(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(req -> {
                     req
-                            .requestMatchers("/public/**", "/actuator/**").permitAll()
+                            .requestMatchers("/public/**", "/actuator/**",
+                                    "/v3/api-docs/**", "/swagger-ui/**").permitAll()
                             .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 
                             .requestMatchers(POST, "/api/v1/students/batch").hasAnyRole(TEACHER.name(), ADMIN.name(), STUDENT.name())

--- a/backend/user-service/src/test/java/com/rusobr/user/securityIT/AbstractSecurityIT.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/securityIT/AbstractSecurityIT.java
@@ -1,0 +1,37 @@
+package com.rusobr.user.securityIT;
+
+import com.rusobr.user.infrastructure.initializer.DebugDataInitializer;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@SpringBootTest(properties = {
+        "eureka.client.enabled=false",
+        "spring.cloud.discovery.enabled=false"
+})
+@AutoConfigureMockMvc
+@Import(SecurityITConfiguration.class)
+public abstract class AbstractSecurityIT {
+
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    static {
+        POSTGRES.start();
+    }
+
+    @MockitoBean
+    private DebugDataInitializer debugDataInitializer;
+
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
+    }
+
+}

--- a/backend/user-service/src/test/java/com/rusobr/user/securityIT/JwtTestUtils.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/securityIT/JwtTestUtils.java
@@ -1,0 +1,92 @@
+package com.rusobr.user.securityIT;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class JwtTestUtils {
+
+    public static final String ISSUER = "http://localhost:9090/realms/dnevnik-realm";
+
+    private static final KeyPair KEY_PAIR = generateKeyPair();
+    private static final RSAKey RSA_KEY = new RSAKey.Builder((RSAPublicKey) KEY_PAIR.getPublic())
+            .privateKey(KEY_PAIR.getPrivate())
+            .build();
+    private static final RSAPublicKey PUBLIC_KEY = (RSAPublicKey) KEY_PAIR.getPublic();
+    private static final JWKSource<SecurityContext> JWK_SOURCE =
+            new ImmutableJWKSet<>(new JWKSet(RSA_KEY));
+
+    private JwtTestUtils() {
+    }
+
+    private static KeyPair generateKeyPair() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            return generator.generateKeyPair();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate test RSA key", e);
+        }
+    }
+
+    public static RSAPublicKey publicKey() {
+        return PUBLIC_KEY;
+    }
+
+    public static String token(Long userId, List<String> roles) {
+        return token(userId, roles, Duration.ofHours(1));
+    }
+
+    public static String token(Long userId, List<String> roles, Duration validity) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("user_id", userId);
+        claims.put("realm_access", Map.of("roles", roles));
+        return token(claims, validity);
+    }
+
+    public static String token(Map<String, Object> claims, Duration validity) {
+        Instant now = Instant.now();
+        JwtClaimsSet claimsSet = JwtClaimsSet.builder()
+                .issuer(ISSUER)
+                .issuedAt(now)
+                .expiresAt(now.plus(validity))
+                .subject(String.valueOf(claims.getOrDefault("user_id", "unknown")))
+                .claims(c -> c.putAll(claims))
+                .build();
+        return sign(claimsSet);
+    }
+
+    public static String expiredToken(Long userId, List<String> roles) {
+        Instant now = Instant.now();
+        JwtClaimsSet claimsSet = JwtClaimsSet.builder()
+                .issuer(ISSUER)
+                .issuedAt(now.minus(Duration.ofHours(2)))
+                .expiresAt(now.minus(Duration.ofHours(1)))
+                .subject(String.valueOf(userId))
+                .claim("user_id", userId)
+                .claim("realm_access", Map.of("roles", roles))
+                .build();
+        return sign(claimsSet);
+    }
+
+    private static String sign(JwtClaimsSet claimsSet) {
+        return new NimbusJwtEncoder(JWK_SOURCE)
+                .encode(JwtEncoderParameters.from(claimsSet))
+                .getTokenValue();
+    }
+
+}

--- a/backend/user-service/src/test/java/com/rusobr/user/securityIT/KeycloakRoleConverterTest.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/securityIT/KeycloakRoleConverterTest.java
@@ -1,0 +1,77 @@
+package com.rusobr.user.securityIT;
+
+import com.rusobr.common.config.SecurityHelper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KeycloakRoleConverterTest {
+
+    private final Converter<Jwt, ? extends AbstractAuthenticationToken> converter =
+            SecurityHelper.keycloakRoleJwtConverter();
+
+    @Test
+    @DisplayName("realm_access.roles -> ROLE_* authorities")
+    void shouldMapRealmAccessRolesToRoleAuthorities() {
+        Jwt jwt = buildJwt(Map.of("realm_access", Map.of("roles", List.of("TEACHER", "USER"))));
+
+        AbstractAuthenticationToken token = converter.convert(jwt);
+
+        assertThat(authorities(token)).containsExactlyInAnyOrder("ROLE_TEACHER", "ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("Отсутствие realm_access -> пустой набор authorities")
+    void shouldReturnEmptyAuthoritiesWhenRealmAccessMissing() {
+        Jwt jwt = buildJwt(Map.of("sub", "user-id-123"));
+
+        AbstractAuthenticationToken token = converter.convert(jwt);
+
+        assertThat(authorities(token)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Нестроковые значения ролей отсеиваются")
+    void shouldIgnoreNonStringRoles() {
+        Jwt jwt = buildJwt(Map.of("realm_access", Map.of("roles", List.of("TEACHER", 123, true))));
+
+        AbstractAuthenticationToken token = converter.convert(jwt);
+
+        assertThat(authorities(token)).containsExactly("ROLE_TEACHER");
+    }
+
+    @Test
+    @DisplayName("resource_access.account не попадает в authorities")
+    void shouldNotMapResourceAccessAccountRoles() {
+        Jwt jwt = buildJwt(Map.of(
+                "realm_access", Map.of("roles", List.of("STUDENT")),
+                "resource_access", Map.of("account", Map.of("roles", List.of("manage-account")))));
+
+        AbstractAuthenticationToken token = converter.convert(jwt);
+
+        assertThat(authorities(token)).containsExactly("ROLE_STUDENT");
+    }
+
+    private Collection<String> authorities(AbstractAuthenticationToken token) {
+        return token.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+    }
+
+    private Jwt buildJwt(Map<String, Object> claims) {
+        return Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .claims(c -> c.putAll(claims))
+                .build();
+    }
+
+}

--- a/backend/user-service/src/test/java/com/rusobr/user/securityIT/OwnershipSecurityIT.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/securityIT/OwnershipSecurityIT.java
@@ -1,0 +1,143 @@
+package com.rusobr.user.securityIT;
+
+import com.rusobr.common.enums.UserRole;
+import com.rusobr.user.domain.model.Student;
+import com.rusobr.user.domain.model.Teacher;
+import com.rusobr.user.domain.model.User;
+import com.rusobr.user.infrastructure.client.feign.AcademicClient;
+import com.rusobr.user.infrastructure.persistence.repository.StudentRepository;
+import com.rusobr.user.infrastructure.persistence.repository.TeacherRepository;
+import com.rusobr.user.infrastructure.persistence.repository.UserRepository;
+import com.rusobr.user.web.dto.feign.AcademicYearResponse;
+import com.rusobr.user.web.dto.feign.SchoolClassResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.http.HttpHeaders;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class OwnershipSecurityIT extends AbstractSecurityIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private StudentRepository studentRepository;
+    @Autowired
+    private TeacherRepository teacherRepository;
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @MockitoBean
+    private AcademicClient academicClient;
+
+    private Long studentOwnerId;
+    private Long studentOtherId;
+    private Long teacherId;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("""
+                TRUNCATE TABLE user_roles, students, teachers, parents, users CASCADE
+                """);
+        cacheManager.getCacheNames().forEach(name -> cacheManager.getCache(name).clear());
+
+        transactionTemplate.executeWithoutResult(status -> {
+            User ownerUser = userRepository.save(User.builder()
+                    .username("student_owner")
+                    .firstName("Иван")
+                    .lastName("Иванов")
+                    .roles(Set.of(UserRole.STUDENT))
+                    .build());
+            studentOwnerId = ownerUser.getId();
+            studentRepository.save(Student.builder()
+                    .user(ownerUser)
+                    .studyProfile("Социо-эконом")
+                    .build());
+
+            User otherUser = userRepository.save(User.builder()
+                    .username("student_other")
+                    .firstName("Пётр")
+                    .lastName("Петров")
+                    .roles(Set.of(UserRole.STUDENT))
+                    .build());
+            studentOtherId = otherUser.getId();
+            studentRepository.save(Student.builder()
+                    .user(otherUser)
+                    .studyProfile("Физ-мат")
+                    .build());
+
+            User teacherUser = userRepository.save(User.builder()
+                    .username("teacher_owner")
+                    .firstName("Анна")
+                    .lastName("Учителева")
+                    .roles(Set.of(UserRole.TEACHER))
+                    .build());
+            teacherId = teacherUser.getId();
+            teacherRepository.save(Teacher.builder()
+                    .user(teacherUser)
+                    .email("anna@school.ru")
+                    .phoneNumber("+7-900-000-0000")
+                    .build());
+        });
+
+        when(academicClient.getSchoolClassByStudentId(any())).thenReturn(
+                new SchoolClassResponse(1L, "5А",
+                        new AcademicYearResponse(1L, "2025-2026", "test",
+                                LocalDate.of(2025, 9, 1), LocalDate.of(2026, 5, 31), true),
+                        teacherId));
+    }
+
+    @Test
+    @DisplayName("Ученик получает свои данные (with-class берёт user_id из JWT) -> 200")
+    void student_OwnData_ShouldReturn200() throws Exception {
+        String studentToken = JwtTestUtils.token(studentOwnerId, List.of("STUDENT"));
+
+        mockMvc.perform(get("/api/v1/students/with-class")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + studentToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Ученик не видит данные другого ученика (info доступен только ADMIN/TEACHER) -> 403")
+    void student_OtherStudentData_ShouldReturn403() throws Exception {
+        String studentToken = JwtTestUtils.token(studentOwnerId, List.of("STUDENT"));
+
+        mockMvc.perform(get("/api/v1/students/{id}/info", studentOtherId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + studentToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Учитель с валидным токеном не имеет доступа к ADMIN-скоупу -> 403")
+    void teacher_NotAdminScope_ShouldReturn403() throws Exception {
+        String teacherToken = JwtTestUtils.token(teacherId, List.of("TEACHER"));
+
+        mockMvc.perform(get("/api/v1/users")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + teacherToken))
+                .andExpect(status().isForbidden());
+    }
+
+}

--- a/backend/user-service/src/test/java/com/rusobr/user/securityIT/ResourceServerSecurityIT.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/securityIT/ResourceServerSecurityIT.java
@@ -1,0 +1,114 @@
+package com.rusobr.user.securityIT;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ResourceServerSecurityIT extends AbstractSecurityIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Запрос без токена -> 401")
+    void noToken_ShouldReturn401() throws Exception {
+        mockMvc.perform(get("/api/v1/users"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Битый токен -> 401")
+    void invalidToken_ShouldReturn401() throws Exception {
+        mockMvc.perform(get("/api/v1/users")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer not-a-valid-jwt"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Подписанный, но просроченный токен -> 401")
+    void expiredToken_ShouldReturn401() throws Exception {
+        String expiredToken = JwtTestUtils.expiredToken(27L, List.of("ADMIN"));
+
+        mockMvc.perform(get("/api/v1/users")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + expiredToken))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Валидный токен с нужной ролью -> 200")
+    void validTokenWithRequiredRole_ShouldReturn200() throws Exception {
+        String adminToken = JwtTestUtils.token(1L, List.of("ADMIN"));
+
+        mockMvc.perform(get("/api/v1/users")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Валидный токен, но недостаточная роль -> 403")
+    void validTokenWithInsufficientRole_ShouldReturn403() throws Exception {
+        String studentToken = JwtTestUtils.token(27L, List.of("STUDENT"));
+
+        mockMvc.perform(get("/api/v1/users")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + studentToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Валидный токен без ролей -> 403")
+    void validTokenWithoutRoles_ShouldReturn403() throws Exception {
+        String noRolesToken = JwtTestUtils.token(Map.of("user_id", 27L), Duration.ofHours(1));
+
+        mockMvc.perform(get("/api/v1/users")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + noRolesToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Публичный actuator/health без токена -> 200")
+    void publicActuatorHealth_WithoutToken_ShouldReturn200() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Публичный /public/** не блокируется security (не 401/403)")
+    void publicPath_WithoutToken_IsNotBlockedBySecurity() throws Exception {
+        MvcResult result = mockMvc.perform(get("/public/nonexistent"))
+                .andReturn();
+
+        assertThat(result.getResponse().getStatus())
+                .as("public path must not be blocked by security")
+                .isNotIn(HttpStatus.UNAUTHORIZED.value(), HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    @DisplayName("Незамапленный URL без токена -> 401")
+    void unmappedUrl_WithoutToken_ShouldReturn401() throws Exception {
+        mockMvc.perform(get("/api/v1/nonexistent-endpoint"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Незамапленный URL с валидным токеном -> 403 (anyRequest.denyAll)")
+    void unmappedUrl_WithToken_ShouldReturn403() throws Exception {
+        String studentToken = JwtTestUtils.token(27L, List.of("STUDENT"));
+
+        mockMvc.perform(get("/api/v1/nonexistent-endpoint")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + studentToken))
+                .andExpect(status().isForbidden());
+    }
+
+}

--- a/backend/user-service/src/test/java/com/rusobr/user/securityIT/SecurityITConfiguration.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/securityIT/SecurityITConfiguration.java
@@ -1,0 +1,16 @@
+package com.rusobr.user.securityIT;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+@TestConfiguration
+public class SecurityITConfiguration {
+
+    @Bean
+    JwtDecoder jwtDecoder() {
+        return NimbusJwtDecoder.withPublicKey(JwtTestUtils.publicKey()).build();
+    }
+
+}


### PR DESCRIPTION
Интеграционные security-тесты для обоих сервисов:
AbstractSecurityIT - общая база: поднимает контекст приложения с мокнутым Keycloak-конвертером, генерирует JWT-токены для ролей.
JwtTestUtils - утилиты создания валидных/протухших/безролевых токенов.
SecurityITConfiguration - конфигурация тестового окружения.
ResourceServerSecurityIT - проверка доступа по ролям: 401 для неавторизованных, 403 без нужной роли, 200 для авторизованных; whitelist-эндпоинты и actuator/health.
OwnershipSecurityIT - IDOR-защита: проверка, что ученик/учитель может мутировать только свои данные.
KeycloakRoleConverterTest  - юнит-тесты маппинга ролей из JWT.

SecurityConfig academic/user/gateway -  разрешён доступ к swagger-ui.