### PR TITLE
test(feign): Интеграционные feign тесты для academic/user сервисов

### DIFF
--- a/backend/academic-service/build.gradle
+++ b/backend/academic-service/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.10'
     implementation 'com.openhtmltopdf:openhtmltopdf-svg-support:1.0.10'
 
+    testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/client/UserClient.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/client/UserClient.java
@@ -13,7 +13,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import java.util.List;
 import java.util.Set;
 
-@FeignClient(value = "user-service", fallbackFactory = UserClientFallbackFactory.class, configuration = FeignConfig.class)
+@FeignClient(value = "user-service", fallbackFactory = UserClientFallbackFactory.class,
+        configuration = FeignConfig.class, url = "${clients.user-service.url:}")
 public interface UserClient {
 
     @GetMapping("/api/v1/teachers/{id}")

--- a/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/client/UserClientFallbackFactory.java
+++ b/backend/academic-service/src/main/java/com/rusobr/academic/infrastructure/client/UserClientFallbackFactory.java
@@ -7,6 +7,7 @@ import com.rusobr.academic.web.exception.BadRequestException;
 import com.rusobr.academic.web.exception.AcademicExceptionCode;
 import com.rusobr.common.exception.ForbiddenException;
 import com.rusobr.common.exception.UnauthorizedException;
+import com.rusobr.common.util.ExceptionUtils;
 import com.rusobr.academic.web.exception.UserServiceUnavailableException;
 import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
@@ -22,49 +23,50 @@ public class UserClientFallbackFactory implements FallbackFactory<UserClient> {
 
     @Override
     public UserClient create(Throwable cause) {
+        Throwable rootCause = ExceptionUtils.unwrapRootCause(cause);
         return new UserClient() {
 
             @Override
             public TeacherResponse getTeacherById(Long id) {
-                handleCommonErrors(cause, "getTeacherById id=" + id,
+                handleCommonErrors(rootCause, "getTeacherById id=" + id,
                         "Not found teacher with id: %d".formatted(id),
                         AcademicExceptionCode.USER_SERVICE_TEACHER_NOT_FOUND);
-                throw fallbackFailure("getTeacherById", id, cause);
+                throw fallbackFailure("getTeacherById", id, rootCause);
             }
 
             @Override
             public UserFeignResponse getTeacherSimpleById(Long id) {
-                handleCommonErrors(cause, "getTeacherSimpleById id=" + id,
+                handleCommonErrors(rootCause, "getTeacherSimpleById id=" + id,
                         "Not found teacher with id: %d".formatted(id),
                         AcademicExceptionCode.USER_SERVICE_TEACHER_NOT_FOUND);
-                throw fallbackFailure("getTeacherSimpleById", id, cause);
+                throw fallbackFailure("getTeacherSimpleById", id, rootCause);
             }
 
             @Override
             public BatchUserResponse getBatchTeachers(List<Long> ids) {
-                handleCommonErrors(cause, "getBatchTeachers ids=" + ids, "Not found batch teachers with ids: %s".formatted(ids),
+                handleCommonErrors(rootCause, "getBatchTeachers ids=" + ids, "Not found batch teachers with ids: %s".formatted(ids),
                         AcademicExceptionCode.USER_SERVICE_BATCH_TEACHERS_NOT_FOUND);
-                throw fallbackFailure("getBatchTeachers", ids, cause);
+                throw fallbackFailure("getBatchTeachers", ids, rootCause);
             }
 
             @Override
             public void existStudentById(Long id) {
-                handleCommonErrors(cause, "existStudentById id=" + id,
+                handleCommonErrors(rootCause, "existStudentById id=" + id,
                         "Not found student with id: %d".formatted(id),
                         AcademicExceptionCode.USER_SERVICE_STUDENT_NOT_FOUND);
-                throw fallbackFailure("existStudentById", id, cause);
+                throw fallbackFailure("existStudentById", id, rootCause);
             }
 
             @Override
             public List<UserFeignResponse> getBatchStudentsExcludeAssigned(Set<Long> ids) {
-                handleCommonErrors(cause, "getBatchStudentsExcludeAssigned ids=" + ids, "Not found batch exclude students with ids: %s".formatted(ids),
+                handleCommonErrors(rootCause, "getBatchStudentsExcludeAssigned ids=" + ids, "Not found batch exclude students with ids: %s".formatted(ids),
                         AcademicExceptionCode.USER_SERVICE_BATCH_EXCLUDE_STUDENTS_NOT_FOUND);
-                throw fallbackFailure("getBatchStudentsExcludeAssigned", ids, cause);
+                throw fallbackFailure("getBatchStudentsExcludeAssigned", ids, rootCause);
             }
 
             @Override
             public BatchUserResponse getBatchStudents(List<Long> ids) {
-                handleCommonErrors(cause, "getBatchUsers ids=" + ids, "Not found batch users with ids: %s".formatted(ids),
+                handleCommonErrors(rootCause, "getBatchUsers ids=" + ids, "Not found batch users with ids: %s".formatted(ids),
                         AcademicExceptionCode.USER_SERVICE_BATCH_USERS_NOT_FOUND);
                 return BatchUserResponse.degraded(ids);
             }

--- a/backend/academic-service/src/test/java/com/rusobr/academic/feignIT/FeignIntegrationTestBase.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/feignIT/FeignIntegrationTestBase.java
@@ -1,0 +1,17 @@
+package com.rusobr.academic.feignIT;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@AutoConfigureWireMock(port = 0)
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "eureka.client.enabled=false",
+        "clients.user-service.url=http://localhost:${wiremock.server.port}",
+        "resilience4j.circuitbreaker.instances.user-service.minimum-number-of-calls=1000000"
+})
+public abstract class FeignIntegrationTestBase {
+}

--- a/backend/academic-service/src/test/java/com/rusobr/academic/feignIT/UserClientIT.java
+++ b/backend/academic-service/src/test/java/com/rusobr/academic/feignIT/UserClientIT.java
@@ -1,0 +1,367 @@
+package com.rusobr.academic.feignIT;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.rusobr.academic.infrastructure.client.UserClient;
+import com.rusobr.academic.web.dto.feign.TeacherResponse;
+import com.rusobr.academic.web.exception.AcademicExceptionCode;
+import com.rusobr.academic.web.exception.BadRequestException;
+import com.rusobr.academic.web.exception.UserServiceUnavailableException;
+import com.rusobr.common.dto.BatchUserResponse;
+import com.rusobr.common.dto.UserFeignResponse;
+import com.rusobr.common.exception.ForbiddenException;
+import com.rusobr.common.exception.UnauthorizedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.removeAllMappings;
+import static com.github.tomakehurst.wiremock.client.WireMock.reset;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class UserClientIT extends FeignIntegrationTestBase {
+
+    @Autowired
+    private UserClient userClient;
+
+    @Test
+    void getTeacherSimpleById_shouldReturnDeserializedTeacher_whenFound() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1/simple"))
+                .willReturn(okJson("""
+                        {
+                            "id": 1,
+                            "firstName": "Учительница",
+                            "lastName": "Учитель",
+                            "username": "teacher_soc",
+                            "keycloakId": "1234-1234-1234"
+                        }
+                        """)));
+
+        UserFeignResponse res = userClient.getTeacherSimpleById(1L);
+
+        assertThat(res).isEqualTo(new UserFeignResponse(1L, "Учительница", "Учитель",
+                "teacher_soc", "1234-1234-1234"));
+    }
+
+    @Test
+    void getTeacherSimpleById_shouldCallExactPath_whenIdProvided() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/42/simple"))
+                .willReturn(okJson("""
+                        { "id": 42, "firstName": "И", "lastName": "П", "username": "u", "keycloakId": "k" }
+                        """)));
+
+        UserFeignResponse res = userClient.getTeacherSimpleById(42L);
+
+        assertThat(res.id()).isEqualTo(42L);
+        verify(getRequestedFor(urlPathEqualTo("/api/v1/teachers/42/simple")));
+    }
+
+    @Test
+    void getTeacherSimpleById_shouldThrowBadRequest_whenServiceReturns404() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/99/simple"))
+                .willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> userClient.getTeacherSimpleById(99L))
+                .isInstanceOfSatisfying(BadRequestException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(AcademicExceptionCode.USER_SERVICE_TEACHER_NOT_FOUND));
+    }
+
+    @Test
+    void getTeacherById_shouldReturnDeserializedTeacherWithNestedFields_whenFound() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1"))
+                .willReturn(okJson("""
+                        {
+                            "user": {
+                                "id": 1,
+                                "firstName": "Иван",
+                                "lastName": "Иванов",
+                                "username": "ivan",
+                                "keycloakId": "kc-1"
+                            },
+                            "details": {
+                                "email": "ivan@test.ru",
+                                "phoneNumber": "+79001234567"
+                            }
+                        }
+                        """)));
+
+        TeacherResponse res = userClient.getTeacherById(1L);
+
+        assertThat(res.user()).isEqualTo(new UserFeignResponse(1L, "Иван", "Иванов", "ivan", "kc-1"));
+        assertThat(res.details().email()).isEqualTo("ivan@test.ru");
+        assertThat(res.details().phoneNumber()).isEqualTo("+79001234567");
+    }
+
+    @Test
+    void getTeacherById_shouldThrowBadRequest_whenServiceReturns404() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/99"))
+                .willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> userClient.getTeacherById(99L))
+                .isInstanceOfSatisfying(BadRequestException.class, e -> {
+                    assertThat(e.getCode()).isEqualTo(AcademicExceptionCode.USER_SERVICE_TEACHER_NOT_FOUND);
+                    assertThat(e.getMessage()).contains("Not found teacher with id: 99");
+                });
+    }
+
+    @Test
+    void getTeacherById_shouldThrowUnauthorized_whenServiceReturns401() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1"))
+                .willReturn(aResponse().withStatus(401)));
+
+        assertThatThrownBy(() -> userClient.getTeacherById(1L))
+                .isInstanceOfSatisfying(UnauthorizedException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(AcademicExceptionCode.USER_SERVICE_UNAUTHORIZED));
+    }
+
+    @Test
+    void getTeacherById_shouldThrowForbidden_whenServiceReturns403() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1"))
+                .willReturn(aResponse().withStatus(403)));
+
+        assertThatThrownBy(() -> userClient.getTeacherById(1L))
+                .isInstanceOfSatisfying(ForbiddenException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(AcademicExceptionCode.USER_SERVICE_FORBIDDEN));
+    }
+
+    @Test
+    void getTeacherById_shouldThrowUnavailable_whenServiceReturns500() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1"))
+                .willReturn(aResponse().withStatus(500)));
+
+        assertThatThrownBy(() -> userClient.getTeacherById(1L))
+                .isInstanceOfSatisfying(UserServiceUnavailableException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(AcademicExceptionCode.USER_SERVICE_UNAVAILABLE));
+    }
+
+    @Test
+    void getBatchTeachers_shouldSendJsonBodyAndReturnDeserializedBatch_whenFound() {
+        stubFor(post(urlPathEqualTo("/api/v1/teachers/batch"))
+                .withRequestBody(equalToJson("[1, 2]"))
+                .willReturn(okJson("""
+                        {
+                            "found": [
+                                { "id": 1, "firstName": "Иван", "lastName": "Иванов", "username": "ivan", "keycloakId": "kc-1" },
+                                { "id": 2, "firstName": "Петр", "lastName": "Петров", "username": "petr", "keycloakId": "kc-2" }
+                            ],
+                            "notFound": [3],
+                            "degraded": false
+                        }
+                        """)));
+
+        BatchUserResponse res = userClient.getBatchTeachers(List.of(1L, 2L));
+
+        assertThat(res.found()).hasSize(2);
+        assertThat(res.found().get(0)).isEqualTo(new UserFeignResponse(1L, "Иван", "Иванов", "ivan", "kc-1"));
+        assertThat(res.found().get(1)).isEqualTo(new UserFeignResponse(2L, "Петр", "Петров", "petr", "kc-2"));
+        assertThat(res.notFound()).containsExactly(3L);
+        assertThat(res.degraded()).isFalse();
+        verify(postRequestedFor(urlPathEqualTo("/api/v1/teachers/batch"))
+                .withRequestBody(equalToJson("[1, 2]")));
+    }
+
+    @Test
+    void getBatchTeachers_shouldReturnEmptyBatch_whenServiceReturnsEmptyBatch() {
+        stubFor(post(urlPathEqualTo("/api/v1/teachers/batch"))
+                .willReturn(okJson("""
+                        { "found": [], "notFound": [], "degraded": false }
+                        """)));
+
+        BatchUserResponse res = userClient.getBatchTeachers(List.of());
+
+        assertThat(res.found()).isEmpty();
+        assertThat(res.notFound()).isEmpty();
+        assertThat(res.degraded()).isFalse();
+    }
+
+    @Test
+    void getBatchTeachers_shouldThrowBadRequest_whenServiceReturns404() {
+        stubFor(post(urlPathEqualTo("/api/v1/teachers/batch"))
+                .willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> userClient.getBatchTeachers(List.of(1L)))
+                .isInstanceOfSatisfying(BadRequestException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(AcademicExceptionCode.USER_SERVICE_BATCH_TEACHERS_NOT_FOUND));
+    }
+
+    @Test
+    void existStudentById_shouldNotThrow_whenServiceReturns200() {
+        stubFor(get(urlPathEqualTo("/api/v1/students/5/details"))
+                .willReturn(ok()));
+
+        assertThatCode(() -> userClient.existStudentById(5L)).doesNotThrowAnyException();
+        verify(getRequestedFor(urlPathEqualTo("/api/v1/students/5/details")));
+    }
+
+    @Test
+    void existStudentById_shouldThrowBadRequest_whenServiceReturns404() {
+        stubFor(get(urlPathEqualTo("/api/v1/students/5/details"))
+                .willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> userClient.existStudentById(5L))
+                .isInstanceOfSatisfying(BadRequestException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(AcademicExceptionCode.USER_SERVICE_STUDENT_NOT_FOUND));
+    }
+
+    @Test
+    void getBatchStudentsExcludeAssigned_shouldSendJsonBodyAndReturnStudents_whenFound() {
+        stubFor(post(urlPathEqualTo("/api/v1/students/exclude-assigned"))
+                .withRequestBody(equalToJson("[1, 2]", true, false))
+                .willReturn(okJson("""
+                        [
+                            { "id": 1, "firstName": "Иван", "lastName": "Иванов", "username": "ivan", "keycloakId": "kc-1" }
+                        ]
+                        """)));
+
+        Set<Long> ids = new LinkedHashSet<>(List.of(1L, 2L));
+
+        List<UserFeignResponse> res = userClient.getBatchStudentsExcludeAssigned(ids);
+
+        assertThat(res).containsExactly(new UserFeignResponse(1L, "Иван", "Иванов", "ivan", "kc-1"));
+        verify(postRequestedFor(urlPathEqualTo("/api/v1/students/exclude-assigned"))
+                .withRequestBody(equalToJson("[1, 2]", true, false)));
+    }
+
+    @Test
+    void getBatchStudentsExcludeAssigned_shouldReturnEmptyList_whenServiceReturnsEmptyArray() {
+        stubFor(post(urlPathEqualTo("/api/v1/students/exclude-assigned"))
+                .willReturn(okJson("[]")));
+
+        assertThat(userClient.getBatchStudentsExcludeAssigned(Set.of())).isEmpty();
+    }
+
+    @Test
+    void getBatchStudentsExcludeAssigned_shouldThrowBadRequest_whenServiceReturns404() {
+        stubFor(post(urlPathEqualTo("/api/v1/students/exclude-assigned"))
+                .willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> userClient.getBatchStudentsExcludeAssigned(Set.of(1L)))
+                .isInstanceOfSatisfying(BadRequestException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(AcademicExceptionCode.USER_SERVICE_BATCH_EXCLUDE_STUDENTS_NOT_FOUND));
+    }
+
+    @Test
+    void getBatchStudents_shouldSendJsonBodyAndReturnDeserializedBatch_whenFound() {
+        stubFor(post(urlPathEqualTo("/api/v1/students/batch"))
+                .withRequestBody(equalToJson("[7]"))
+                .willReturn(okJson("""
+                        {
+                            "found": [ { "id": 7, "firstName": "Оля", "lastName": "Орлова", "username": "ola", "keycloakId": "kc-7" } ],
+                            "notFound": [],
+                            "degraded": false
+                        }
+                        """)));
+
+        BatchUserResponse res = userClient.getBatchStudents(List.of(7L));
+
+        assertThat(res.found()).containsExactly(new UserFeignResponse(7L, "Оля", "Орлова", "ola", "kc-7"));
+        assertThat(res.notFound()).isEmpty();
+        assertThat(res.degraded()).isFalse();
+        verify(postRequestedFor(urlPathEqualTo("/api/v1/students/batch"))
+                .withRequestBody(equalToJson("[7]")));
+    }
+
+    @Test
+    void getBatchStudents_shouldThrowBadRequest_whenServiceReturns404() {
+        stubFor(post(urlPathEqualTo("/api/v1/students/batch"))
+                .willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> userClient.getBatchStudents(List.of(1L)))
+                .isInstanceOfSatisfying(BadRequestException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(AcademicExceptionCode.USER_SERVICE_BATCH_USERS_NOT_FOUND));
+    }
+
+    @Test
+    void getBatchStudents_shouldReturnDegradedBatch_whenServiceReturns500() {
+        stubFor(post(urlPathEqualTo("/api/v1/students/batch"))
+                .willReturn(aResponse().withStatus(500)));
+
+        BatchUserResponse res = userClient.getBatchStudents(List.of(1L, 2L));
+
+        assertThat(res.degraded()).isTrue();
+        assertThat(res.found()).extracting(UserFeignResponse::id).containsExactly(1L, 2L);
+        assertThat(res.found()).allMatch(u -> u.firstName() == null);
+        assertThat(res.notFound()).isEmpty();
+    }
+
+    @Test
+    void getTeacherById_shouldThrowUnavailable_whenConnectionResetByPeer() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1"))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        assertThatThrownBy(() -> userClient.getTeacherById(1L))
+                .isInstanceOfSatisfying(UserServiceUnavailableException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(AcademicExceptionCode.USER_SERVICE_UNAVAILABLE));
+    }
+
+    @Test
+    void getTeacherById_shouldThrowUnavailable_whenResponseExceedsReadTimeout() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1"))
+                .willReturn(okJson("""
+                        { "user": null, "details": null }
+                        """).withFixedDelay(2000)));
+
+        assertThatThrownBy(() -> userClient.getTeacherById(1L))
+                .isInstanceOfSatisfying(UserServiceUnavailableException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(AcademicExceptionCode.USER_SERVICE_UNAVAILABLE));
+    }
+
+    @Test
+    void feignCall_shouldPropagateAuthHeaderFromSecurityContext() {
+        Jwt jwt = Jwt.withTokenValue("incoming")
+                .header("alg", "RS256")
+                .claim("sub", "teacher-1")
+                .build();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt, List.of()));
+
+        stubFor(post(urlPathEqualTo("/api/v1/students/batch"))
+                .willReturn(okJson("""
+                        { "found": [], "notFound": [], "degraded": false }
+                        """)));
+
+        userClient.getBatchStudents(List.of(1L));
+
+        verify(postRequestedFor(urlPathEqualTo("/api/v1/students/batch"))
+                .withHeader("Authorization", equalTo("Bearer incoming")));
+    }
+
+    @Test
+    void feignCall_shouldNotSendAuthorizationHeader_whenSecurityContextEmpty() {
+        stubFor(post(urlPathEqualTo("/api/v1/students/batch"))
+                .willReturn(okJson("""
+                        { "found": [], "notFound": [], "degraded": false }
+                        """)));
+
+        userClient.getBatchStudents(List.of(1L));
+
+        verify(postRequestedFor(urlPathEqualTo("/api/v1/students/batch"))
+                .withoutHeader("Authorization"));
+    }
+
+    @AfterEach
+    void cleanUp() {
+        SecurityContextHolder.clearContext();
+        removeAllMappings();
+        reset();
+    }
+}

--- a/backend/academic-service/src/test/resources/application-test.yml
+++ b/backend/academic-service/src/test/resources/application-test.yml
@@ -1,0 +1,8 @@
+spring:
+  cloud:
+    openfeign:
+      client:
+        config:
+          default:
+            connect-timeout: 500
+            read-timeout: 500

--- a/backend/common/src/main/java/com/rusobr/common/util/ExceptionUtils.java
+++ b/backend/common/src/main/java/com/rusobr/common/util/ExceptionUtils.java
@@ -1,0 +1,25 @@
+package com.rusobr.common.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+public final class ExceptionUtils {
+
+    private ExceptionUtils() {
+    }
+
+    public static Throwable unwrapRootCause(Throwable throwable) {
+        Throwable current = throwable;
+        while (isAsyncWrapper(current) && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    private static boolean isAsyncWrapper(Throwable throwable) {
+        return throwable instanceof ExecutionException
+                || throwable instanceof CompletionException
+                || throwable instanceof InvocationTargetException;
+    }
+}

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'

--- a/backend/user-service/src/main/java/com/rusobr/user/infrastructure/client/feign/AcademicClient.java
+++ b/backend/user-service/src/main/java/com/rusobr/user/infrastructure/client/feign/AcademicClient.java
@@ -8,7 +8,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(value = "academic-service", fallbackFactory = AcademicClientFallbackFactory.class, configuration = FeignConfig.class)
+@FeignClient(value = "academic-service", fallbackFactory = AcademicClientFallbackFactory.class,
+        configuration = FeignConfig.class, url = "${clients.academic-service.url:}")
 public interface AcademicClient {
 
     @GetMapping("/api/v1/school-classes/search/by-student")

--- a/backend/user-service/src/main/java/com/rusobr/user/infrastructure/client/feign/AcademicClientFallbackFactory.java
+++ b/backend/user-service/src/main/java/com/rusobr/user/infrastructure/client/feign/AcademicClientFallbackFactory.java
@@ -3,6 +3,7 @@ package com.rusobr.user.infrastructure.client.feign;
 import com.rusobr.common.exception.ForbiddenException;
 import com.rusobr.common.exception.NotFoundException;
 import com.rusobr.common.exception.UnauthorizedException;
+import com.rusobr.common.util.ExceptionUtils;
 import com.rusobr.user.web.dto.feign.SchoolClassResponse;
 import com.rusobr.user.web.dto.feign.TeacherAcademicFeignDto;
 import com.rusobr.user.web.exception.*;
@@ -17,28 +18,29 @@ public class AcademicClientFallbackFactory implements FallbackFactory<AcademicCl
 
     @Override
     public AcademicClient create(Throwable cause) {
+        Throwable rootCause = ExceptionUtils.unwrapRootCause(cause);
         return new AcademicClient() {
 
             @Override
             public SchoolClassResponse getSchoolClassByStudentId(Long studentId) {
                 handleCommonErrors(
-                        cause,
+                        rootCause,
                         "getSchoolClassByStudentId",
                         "School class with %s not found".formatted(studentId),
                         UserExceptionCode.SCHOOL_CLASS_BY_STUDENT_NOT_FOUND
                 );
-                throw fallbackFailure("getSchoolClassByStudentId", studentId, cause);
+                throw fallbackFailure("getSchoolClassByStudentId", studentId, rootCause);
             }
 
             @Override
             public TeacherAcademicFeignDto getTeacherAcademicInfo(Long teacherId) {
                 handleCommonErrors(
-                        cause,
+                        rootCause,
                         "getTeacherAcademicInfo",
                         "Teacher info with id: %s not found".formatted(teacherId),
                         UserExceptionCode.ACADEMIC_SERVICE_TEACHER_INFO_NOT_FOUND
                 );
-                throw fallbackFailure("getTeacherAcademicInfo", teacherId, cause);
+                throw fallbackFailure("getTeacherAcademicInfo", teacherId, rootCause);
             }
         };
     }

--- a/backend/user-service/src/test/java/com/rusobr/user/feignIT/AcademicClientIT.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/feignIT/AcademicClientIT.java
@@ -1,0 +1,261 @@
+package com.rusobr.user.feignIT;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.rusobr.common.exception.ForbiddenException;
+import com.rusobr.common.exception.NotFoundException;
+import com.rusobr.common.exception.UnauthorizedException;
+import com.rusobr.user.infrastructure.client.feign.AcademicClient;
+import com.rusobr.user.web.dto.feign.AcademicYearResponse;
+import com.rusobr.user.web.dto.feign.SchoolClassResponse;
+import com.rusobr.user.web.dto.feign.TeacherAcademicFeignDto;
+import com.rusobr.user.web.exception.AcademicServiceUnavailableException;
+import com.rusobr.user.web.exception.UserExceptionCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.*;
+
+public class AcademicClientIT extends FeignIntegrationTestBase {
+
+    @Autowired
+    private AcademicClient academicClient;
+
+    @Test
+    void getSchoolClassByStudentId_shouldReturnDeserializedSchoolClass_whenFound() {
+        stubFor(get(urlPathEqualTo("/api/v1/school-classes/search/by-student"))
+                .withQueryParam("studentId", equalTo("1"))
+                .willReturn(okJson("""
+                        {
+                            "id": 1,
+                            "name": "8A",
+                            "academicYear": {
+                              "id": 1,
+                              "name": "2025-2026",
+                              "description": "123",
+                              "startDate": "2025-04-30",
+                              "endDate": "2025-05-30",
+                              "isActive": true
+                            },
+                            "classTeacherId": 27
+                        }
+                        """)));
+
+        SchoolClassResponse res = academicClient.getSchoolClassByStudentId(1L);
+
+        assertThat(res).isEqualTo(new SchoolClassResponse(1L, "8A", new AcademicYearResponse(1L, "2025-2026", "123",
+                LocalDate.of(2025, 4, 30), LocalDate.of(2025, 5, 30), true), 27L));
+    }
+
+    @Test
+    void getSchoolClassByStudentId_shouldSendCorrectQueryParam_whenIdProvided() {
+        stubFor(get(urlPathEqualTo("/api/v1/school-classes/search/by-student"))
+                .willReturn(okJson("""
+                        {
+                            "id": 1,
+                            "name": "8A",
+                            "academicYear": {
+                              "id": 1,
+                              "name": "2025-2026",
+                              "description": "123",
+                              "startDate": "2025-04-30",
+                              "endDate": "2025-05-30",
+                              "isActive": true
+                            },
+                            "classTeacherId": 27
+                        }
+                        """)));
+
+        SchoolClassResponse res = academicClient.getSchoolClassByStudentId(42L);
+
+        assertThat(res.id()).isEqualTo(1);
+        verify(getRequestedFor(urlPathEqualTo("/api/v1/school-classes/search/by-student"))
+                .withQueryParam("studentId", equalTo("42")));
+    }
+
+    @Test
+    void getSchoolClassByStudentId_shouldThrowNotFound_whenServiceReturns404() {
+        stubFor(get(urlPathEqualTo("/api/v1/school-classes/search/by-student"))
+                .willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> academicClient.getSchoolClassByStudentId(99L))
+                .isInstanceOfSatisfying(NotFoundException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(UserExceptionCode.SCHOOL_CLASS_BY_STUDENT_NOT_FOUND));
+    }
+
+    @Test
+    void getSchoolClassByStudentId_shouldThrowUnauthorized_whenServiceReturns401() {
+        stubFor(get(urlPathEqualTo("/api/v1/school-classes/search/by-student"))
+                .willReturn(aResponse().withStatus(401)));
+
+        assertThatThrownBy(() -> academicClient.getSchoolClassByStudentId(1L))
+                .isInstanceOfSatisfying(UnauthorizedException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(UserExceptionCode.ACADEMIC_SERVICE_UNAUTHORIZED));
+    }
+
+    @Test
+    void getSchoolClassByStudentId_shouldThrowForbidden_whenServiceReturns403() {
+        stubFor(get(urlPathEqualTo("/api/v1/school-classes/search/by-student"))
+                .willReturn(aResponse().withStatus(403)));
+
+        assertThatThrownBy(() -> academicClient.getSchoolClassByStudentId(1L))
+                .isInstanceOfSatisfying(ForbiddenException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(UserExceptionCode.ACADEMIC_SERVICE_FORBIDDEN));
+    }
+
+    @Test
+    void getSchoolClassByStudentId_shouldThrowUnavailable_whenConnectionResetByPeer() {
+        stubFor(get(urlPathEqualTo("/api/v1/school-classes/search/by-student"))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        assertThatThrownBy(() -> academicClient.getSchoolClassByStudentId(1L))
+                .isInstanceOfSatisfying(AcademicServiceUnavailableException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(UserExceptionCode.ACADEMIC_SERVICE_UNAVAILABLE));
+    }
+
+    @Test
+    void getTeacherAcademicInfo_shouldReturnDeserializedInfo_whenFound() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1/info"))
+                .willReturn(okJson("""
+                        {
+                            "subjects": [
+                                { "subject": { "id": 10, "name": "Математика" } }
+                            ],
+                            "classes": [
+                                {
+                                    "id": 1,
+                                    "name": "8A",
+                                    "academicYear": {
+                                        "id": 1,
+                                        "name": "2025-2026",
+                                        "description": "123",
+                                        "startDate": "2025-04-30",
+                                        "endDate": "2025-05-30",
+                                        "isActive": true
+                                    },
+                                    "classTeacherId": 27
+                                }
+                            ],
+                            "assignments": [
+                                {
+                                    "id": 5,
+                                    "subject": { "id": 10, "name": "Математика" },
+                                    "schoolClass": {
+                                        "id": 1,
+                                        "name": "8A",
+                                        "academicYear": {
+                                            "id": 1,
+                                            "name": "2025-2026",
+                                            "description": "123",
+                                            "startDate": "2025-04-30",
+                                            "endDate": "2025-05-30",
+                                            "isActive": true
+                                        },
+                                        "classTeacherId": 27
+                                    }
+                                }
+                            ]
+                        }
+                        """)));
+
+        TeacherAcademicFeignDto res = academicClient.getTeacherAcademicInfo(1L);
+
+        assertThat(res.subjects()).hasSize(1);
+        assertThat(res.subjects().get(0).subject().name()).isEqualTo("Математика");
+        assertThat(res.classes()).hasSize(1);
+        assertThat(res.classes().get(0).name()).isEqualTo("8A");
+        assertThat(res.assignments()).hasSize(1);
+        assertThat(res.assignments().get(0).id()).isEqualTo(5L);
+        assertThat(res.assignments().get(0).schoolClass().classTeacherId()).isEqualTo(27L);
+
+        verify(getRequestedFor(urlPathEqualTo("/api/v1/teachers/1/info")));
+    }
+
+    @Test
+    void getTeacherAcademicInfo_shouldThrowNotFound_whenServiceReturns404() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/99/info"))
+                .willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> academicClient.getTeacherAcademicInfo(99L))
+                .isInstanceOfSatisfying(NotFoundException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(UserExceptionCode.ACADEMIC_SERVICE_TEACHER_INFO_NOT_FOUND));
+    }
+
+    @Test
+    void getTeacherAcademicInfo_shouldThrowUnauthorized_whenServiceReturns401() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1/info"))
+                .willReturn(aResponse().withStatus(401)));
+
+        assertThatThrownBy(() -> academicClient.getTeacherAcademicInfo(1L))
+                .isInstanceOfSatisfying(UnauthorizedException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(UserExceptionCode.ACADEMIC_SERVICE_UNAUTHORIZED));
+    }
+
+    @Test
+    void getTeacherAcademicInfo_shouldThrowForbidden_whenServiceReturns403() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1/info"))
+                .willReturn(aResponse().withStatus(403)));
+
+        assertThatThrownBy(() -> academicClient.getTeacherAcademicInfo(1L))
+                .isInstanceOfSatisfying(ForbiddenException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(UserExceptionCode.ACADEMIC_SERVICE_FORBIDDEN));
+    }
+
+    @Test
+    void getTeacherAcademicInfo_shouldThrowUnavailable_whenResponseExceedsReadTimeout() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1/info"))
+                .willReturn(okJson("""
+                        { "subjects": [], "classes": [], "assignments": [] }
+                        """).withFixedDelay(2000)));
+
+        assertThatThrownBy(() -> academicClient.getTeacherAcademicInfo(1L))
+                .isInstanceOfSatisfying(AcademicServiceUnavailableException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(UserExceptionCode.ACADEMIC_SERVICE_UNAVAILABLE));
+    }
+
+    @Test
+    void feignCall_shouldPropagateAuthHeaderFromSecurityContext() {
+        Jwt jwt = Jwt.withTokenValue("incoming")
+                .header("alg", "RS256")
+                .claim("sub", "teacher-1")
+                .build();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt, List.of()));
+
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1/info"))
+                .willReturn(okJson("""
+                        { "subjects": [], "classes": [], "assignments": [] }
+                        """)));
+
+        academicClient.getTeacherAcademicInfo(1L);
+
+        verify(getRequestedFor(urlPathEqualTo("/api/v1/teachers/1/info"))
+                .withHeader("Authorization", equalTo("Bearer incoming")));
+    }
+
+    @Test
+    void feignCall_shouldNotSendAuthorizationHeader_whenSecurityContextEmpty() {
+        stubFor(get(urlPathEqualTo("/api/v1/teachers/1/info"))
+                .willReturn(okJson("""
+                        { "subjects": [], "classes": [], "assignments": [] }
+                        """)));
+
+        academicClient.getTeacherAcademicInfo(1L);
+
+        verify(getRequestedFor(urlPathEqualTo("/api/v1/teachers/1/info"))
+                .withoutHeader("Authorization"));
+    }
+
+    @AfterEach
+    void cleanUp() {
+        SecurityContextHolder.clearContext();
+        removeAllMappings();
+        reset();
+    }
+}

--- a/backend/user-service/src/test/java/com/rusobr/user/feignIT/FeignIntegrationTestBase.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/feignIT/FeignIntegrationTestBase.java
@@ -1,23 +1,24 @@
-package com.rusobr.user.securityIT;
+package com.rusobr.user.feignIT;
 
 import com.rusobr.user.infrastructure.initializer.DebugDataInitializer;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.PostgreSQLContainer;
 
-@SpringBootTest(properties = {
-        "eureka.client.enabled=false",
-        "spring.cloud.discovery.enabled=false"
-})
-@AutoConfigureMockMvc
+@SpringBootTest
+@AutoConfigureWireMock(port = 0)
 @ActiveProfiles("test")
-@Import(SecurityITConfiguration.class)
-public abstract class AbstractSecurityIT {
+@TestPropertySource(properties = {
+        "eureka.client.enabled=false",
+        "clients.academic-service.url=http://localhost:${wiremock.server.port}",
+        "resilience4j.circuitbreaker.instances.academic-service.minimum-number-of-calls=1000000"
+})
+public abstract class FeignIntegrationTestBase {
 
     static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
 
@@ -35,5 +36,4 @@ public abstract class AbstractSecurityIT {
         registry.add("spring.datasource.password", POSTGRES::getPassword);
         registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
     }
-
 }

--- a/backend/user-service/src/test/java/com/rusobr/user/jpaIT/AbstractRepositoryIT.java
+++ b/backend/user-service/src/test/java/com/rusobr/user/jpaIT/AbstractRepositoryIT.java
@@ -4,11 +4,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 @DataJpaTest
+@ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public abstract class AbstractRepositoryIT {
 

--- a/backend/user-service/src/test/resources/application-test.yml
+++ b/backend/user-service/src/test/resources/application-test.yml
@@ -1,0 +1,8 @@
+spring:
+  cloud:
+    openfeign:
+      client:
+        config:
+          default:
+            connect-timeout: 500
+            read-timeout: 500


### PR DESCRIPTION
- Исправил обработку feign exception в fallback factory при котом ошибки оборачивались изза circuit breaker в ExecutionException
- в тестах использовал wireMock для имитации вызовов и отключал eureka server
- в feign клиентах указал url = "${clients.|service-name|-service.url:}") в тестах можно имитировать обращение к сервису а если не указывать то используется название сервиса из discovery lb://

Closes #138